### PR TITLE
Add missing meta tags in docs and addons index pages

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -26,6 +26,11 @@ initial_gallery:
     description: "These add-ons provide voice enabling features, such as text-to-speech, speech-to-text etc."
     featured: ["mactts", "marytts", "voicerss"]
     all: true
+meta:
+  - name: og:title
+    content: openHAB Add-ons
+  - name: og:description
+    content: a vendor and technology agnostic open source automation software for your home
 ---
 
 <h1 class="welcome">Add-on Reference</h1>

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,5 +1,10 @@
 ---
 title: Introduction
+meta:
+  - name: og:title
+    content: Welcome to openHAB!
+  - name: og:description
+    content: a vendor and technology agnostic open source automation software for your home
 ---
 
 <h1 class="welcome">Welcome to openHAB!</h1>


### PR DESCRIPTION
Signed-off-by: Yannick Schaus <github@schaus.net>