### PR TITLE
Use end_date for events upcoming/past threshold

### DIFF
--- a/.vuepress/components/CalendarIcon.vue
+++ b/.vuepress/components/CalendarIcon.vue
@@ -83,7 +83,7 @@ export default {
   data () {
     const date = new Date(this.date)
     const endDate = new Date(this.endDate)
-    const multiple_days = !endDate || (date.getDate() !== endDate.getDate())
+    const multiple_days = !isNaN(endDate) && (date.getDate() !== endDate.getDate())
     return {
       month: months[date.getMonth()],
       weekday: (multiple_days) ? shortDays[date.getDay()] + '	- ' + shortDays[endDate.getDay()] : days[date.getDay()],

--- a/.vuepress/components/home/EventsSection.vue
+++ b/.vuepress/components/home/EventsSection.vue
@@ -170,7 +170,8 @@ export default {
     }
   },
   mounted () {
-    this.events = this.$site.pages.filter((p) => new Date(p.frontmatter.date) > new Date() && p.frontmatter.layout === 'Event')
+    this.events = this.$site.pages.filter((p) => p.frontmatter.layout === 'Event' &&
+        p.frontmatter.end_date ? new Date(p.frontmatter.end_date) >= new Date() : new Date(p.frontmatter.date) >= new Date())
       .sort((e1,e2) => new Date(e1.frontmatter.date) > new Date(e2.frontmatter.date))
       .slice(0, 2)
   }

--- a/about/events.md
+++ b/about/events.md
@@ -16,7 +16,8 @@ If you are organizing an event around openHAB, please let us know in the [Events
   <h2>Upcoming events</h2>
 
   <ul class="event-list">
-    <li v-for="page in $site.pages.filter((p) => new Date(p.frontmatter.date) > new Date() && p.frontmatter.layout === 'Event')
+    <li v-for="page in $site.pages.filter((p) => p.frontmatter.layout === 'Event' &&
+                (p.frontmatter.end_date) ? new Date(p.frontmatter.end_date) >= new Date() : new Date(p.frontmatter.date) >= new Date())
             .sort((e1,e2) => new Date(e1.frontmatter.date) > new Date(e2.frontmatter.date))" class="event">
       <div class="calendar"><calendar-icon :date="page.frontmatter.date" :end-date="page.frontmatter.end_date"></calendar-icon></div>
       <a :href="page.frontmatter.link" target="_blank" class="event-link"><img class="event-image" :src="page.frontmatter.event_image || '/openhab-logo.png'" /></a>
@@ -36,8 +37,8 @@ If you are organizing an event around openHAB, please let us know in the [Events
   <div v-for="year in [2018]"> <!-- don't forget to add previous years :) -->
     <h3>{{year}}</h3>
     <ul class="event-list">
-      <li v-for="page in $site.pages.filter((p) => new Date(p.frontmatter.date) <= new Date()
-                && p.frontmatter.layout === 'Event' && new Date(p.frontmatter.date).getFullYear() === year)
+      <li v-for="page in $site.pages.filter((p) => p.frontmatter.layout === 'Event' && new Date(p.frontmatter.date).getFullYear() === year &&
+                  ((p.frontmatter.end_date) ? new Date(p.frontmatter.end_date) < new Date() : new Date(p.frontmatter.date) < new Date()))
               .sort((e1,e2) => new Date(e1.frontmatter.date) < new Date(e2.frontmatter.date))" class="event">
         <div class="calendar"><calendar-icon :date="page.frontmatter.date" :end-date="page.frontmatter.end_date"></calendar-icon></div>
         <a :href="page.frontmatter.link" target="_blank" class="event-link"><img class="event-image" :src="page.frontmatter.event_image || '/openhab-logo.png'" /></a>

--- a/about/events/2018-05-13-building-iot.md
+++ b/about/events/2018-05-13-building-iot.md
@@ -5,7 +5,7 @@ title: building IoT 2018
 organizer: dpunkt.verlag GmbH
 link: 'https://www.buildingiot.de/'
 date: '2018-06-04T23:49:15+02:00'
-end_date: '2018-06-06T00:00:00+02:00'
+end_date: '2018-06-06T18:00:00+02:00'
 location: 'Köln, Germany'
 event_image: /uploads/buildingiot2018.png
 abstract: The building IoT conference is renowned for deep technical insights into the software engineering aspects of the Internet of Things. Kai is a member of the program committee and he also presents openHAB in his talk about smart home interoperability.

--- a/about/events/2018-05-13-silicon-saxony-day-2018.md
+++ b/about/events/2018-05-13-silicon-saxony-day-2018.md
@@ -5,7 +5,6 @@ title: Silicon Saxony Day 2018
 organizer: Silicon Saxony e.V.
 link: 'https://www.silicon-saxony.de/silicon-saxony-day/'
 date: '2018-05-29T23:33:16+02:00'
-end_date: '2018-05-29T00:00:00+02:00'
 location: 'Dresden, Germany'
 event_image: /uploads/sisax2018.jpg
 abstract: Kai participates in the expert sessions and talks about interoperability in the IoT in the presentation "Mastering the diversity in smart buildings - A practical approach with openHAB"

--- a/about/events/2018-05-17-sinteg-jahreskonferenz-2018.md
+++ b/about/events/2018-05-17-sinteg-jahreskonferenz-2018.md
@@ -6,7 +6,7 @@ organizer: ' Bundesministeriums für Wirtschaft und Energie'
 link: >-
   https://www.sinteg.de/termine/aktuelle-termine/detailseite/sinteg-jahreskonferenz-2018/
 date: '2018-06-05T12:49:11+02:00'
-end_date: '2018-06-06T12:49:11+02:00'
+end_date: '2018-06-06T18:00:11+02:00'
 location: 'Berlin, Germany'
 event_image: /uploads/sinteg.jpg
 abstract: >-

--- a/about/events/2018-05-25-eclipse-democamp-2018.md
+++ b/about/events/2018-05-25-eclipse-democamp-2018.md
@@ -5,7 +5,6 @@ title: Eclipse DemoCamp 2018
 organizer: Deutsche Telekom AG
 link: 'https://wiki.eclipse.org/Eclipse_DemoCamps_2018/Darmstadt'
 date: '2018-06-20T17:38:29+02:00'
-end_date: '2018-06-20T17:38:29+02:00'
 location: 'Darmstadt, Germany'
 event_image: /uploads/democamp.png
 abstract: >-

--- a/about/events/2018-05-27-smart-home-day-2018.md
+++ b/about/events/2018-05-27-smart-home-day-2018.md
@@ -4,7 +4,6 @@ category: event
 title: Smart Home Day 2018
 organizer: openHAB Foundation e.V.
 date: '2018-10-21T17:26:50+02:00'
-end_date: '2018-05-21T17:26:50+02:00'
 location: 'Ludwigsburg, Germany'
 event_image: /uploads/shd2018.png
 abstract: >-

--- a/about/events/2018-06-17-berlin-openhab-meetup.md
+++ b/about/events/2018-06-17-berlin-openhab-meetup.md
@@ -5,7 +5,6 @@ title: Berlin openHAB meetup
 organizer: Simon Tennant
 link: 'https://www.eventbrite.com/e/openhab-berlin-meetup-tickets-46524204147'
 date: '2018-06-17T23:33:16+02:00'
-end_date: '2018-06-17T00:00:00+02:00'
 location: 'Berlin, Germany'
 abstract: A meetup of openHAB enthusiasts in Berlin to talk about their use of openHAB, hacks, rules, bindings and implementations.
 ---


### PR DESCRIPTION
Can be omitted (e.g. for one-day events), then
"date" will continue to be used.
Fixes #63.

Signed-off-by: Yannick Schaus <github@schaus.net>