### PR TITLE
 Prepare for stable documentation websites generation

### DIFF
--- a/.vuepress/components/AddonLogo.vue
+++ b/.vuepress/components/AddonLogo.vue
@@ -1,5 +1,5 @@
 <template>
-  <img :src="$page.frontmatter.logo.replace('images/addons/', $site.base + '/logos/')" class="addon-logo" />
+  <img :src="$page.frontmatter.logo.replace('images/addons/', $site.base + 'logos/')" class="addon-logo" />
 </template>
 
 <style lang="stylus">

--- a/.vuepress/components/AddonLogo.vue
+++ b/.vuepress/components/AddonLogo.vue
@@ -1,5 +1,5 @@
 <template>
-  <img :src="$page.frontmatter.logo.replace('images/addons/', '/logos/')" class="addon-logo" />
+  <img :src="$page.frontmatter.logo.replace('images/addons/', $site.base + '/logos/')" class="addon-logo" />
 </template>
 
 <style lang="stylus">

--- a/.vuepress/components/DocPreviousVersions.vue
+++ b/.vuepress/components/DocPreviousVersions.vue
@@ -2,13 +2,13 @@
   <div class="page-versions">
     <div class="dropdown-wrapper" :class="{ open }">
       <a class="dropdown-title" @click="toggle">
-        <span class="title">Other versions</span>
+        <span class="title">Version: {{currentVersion}}</span>
         <span class="arrow" :class="open ? 'down' : 'right'"></span></span>
       </a>
       <ul class="nav-dropdown" v-show="open">
         <li v-for="version in versions" class="dropdown-item">
           <a class="current" v-if="version.number === currentVersion">{{version.number}}</a>
-          <a v-else :href="version.url" target="_blank">{{version.number}}</a>
+          <a v-else :href="version.url">{{version.number}}</a>
         </li>
       </ul>
     </div>
@@ -69,7 +69,7 @@
 export default {
   data () {
     return {
-      versionNumbers: ['latest', '2.2', '2.1'],
+      versionNumbers: ['latest', '2.3', '2.2', '2.1'],
       currentVersion: 'latest',
       open: false
     }
@@ -79,16 +79,29 @@ export default {
       this.open = !this.open
     }
   },
+  created () {
+    if (this.$site.base && this.$site.base.indexOf('v') > 0) {
+      this.currentVersion = this.$site.base.replace('v', '').replace(/\//g, '')
+      this.versionNumbers = ['latest', this.currentVersion] // to avoid having to regenerate previous sites
+    }
+  },
   computed: {
     versions () {
       return this.versionNumbers.map(version => {
-        let url = `${this.$page.path
-          .replace('/docs/', '').replace('/addons/', 'addons/').replace('addons/integrations/', 'addons/ios/')}`
-        if (url.indexOf('addons') === 0) url += 'readme.html'
+        let url = this.$page.path
+        if (version === '2.2' || version === '2.1') {
+          url = url.replace('addons/integrations/', 'addons/ios/')
+          if (url.indexOf('/addons') === 0) url += 'readme.html'
+        }
+        if (version === 'latest') {
+          url = 'https://www.openhab.org' + url
+        } else {
+          url = `https://${version === '2.3' ? 'docs.' : ''}openhab.org${version === 'snapshot' ? '' : '/v' + version}${url}`
+        }
 
         return {
           number: version,
-          url: `https://docs.openhab.org${version === 'snapshot' ? '' : '/v' + version}/${url}`
+          url: url
         }
       })
     }

--- a/.vuepress/components/DocPreviousVersions.vue
+++ b/.vuepress/components/DocPreviousVersions.vue
@@ -96,7 +96,7 @@ export default {
         if (version === 'latest') {
           url = 'https://www.openhab.org' + url
         } else {
-          url = `https://${(version === '2.2' || version === '2.1') ? 'docs.' : ''}openhab.org${version === 'snapshot' ? '' : '/v' + version}${url}`
+          url = `https://${(version === '2.2' || version === '2.1') ? 'docs.' : 'www.'}openhab.org${version === 'snapshot' ? '' : '/v' + version}${url}`
         }
 
         return {

--- a/.vuepress/components/DocPreviousVersions.vue
+++ b/.vuepress/components/DocPreviousVersions.vue
@@ -96,7 +96,7 @@ export default {
         if (version === 'latest') {
           url = 'https://www.openhab.org' + url
         } else {
-          url = `https://${version === '2.3' ? 'docs.' : ''}openhab.org${version === 'snapshot' ? '' : '/v' + version}${url}`
+          url = `https://${(version === '2.2' || version === '2.1') ? 'docs.' : ''}openhab.org${version === 'snapshot' ? '' : '/v' + version}${url}`
         }
 
         return {

--- a/.vuepress/components/EditPageLink.vue
+++ b/.vuepress/components/EditPageLink.vue
@@ -18,6 +18,9 @@
 .esh-note
   color #999
   font-size 8pt
+  svg
+    height: 10px !important
+    width: 10px !important
 </style>
 
 <script>

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -12,7 +12,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 const HighlightDsl = require('./highlight-dsl')
 const HighlightRules = require('./highlight-rules')
 
-const base = process.env.GH ? '/vuepress/' : '/'
+const base = process.env.OH_DOCS_VERSION ? `/v${process.env.OH_DOCS_VERSION}/` : '/'
 
 module.exports = {
   title: 'openHAB',
@@ -22,11 +22,11 @@ module.exports = {
   base,
   ga: 'UA-47717934-1',
   head: [
-    ['link', { rel: 'stylesheet', href: `/fonts/fonts.css` }],
+    // ['link', { rel: 'stylesheet', href: `/fonts/fonts.css` }],
     ['link', { rel: 'icon', href: `/favicon.ico` }],
     ['link', { rel: 'shortcut icon', href: `/favicon.ico` }],
     ['link', { rel: 'apple-touch-icon', href: `/apple-icon.png` }],
-    // ['link', { rel: 'stylesheet', href: `//fonts.googleapis.com/css?family=Open+Sans:300,400` }],
+    ['link', { rel: 'stylesheet', href: `https://fonts.googleapis.com/css?family=Open+Sans:300,400` }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:image', content: 'https://www.openhab.org/og-image.png' }],
     // ['meta', { property: 'og:title', content: 'openHAB' }],
@@ -191,7 +191,7 @@ module.exports = {
             'concepts/items',
             'concepts/discovery',
             'concepts/audio',
-            'concepts/units-of-measurement',
+            'concepts/units-of-measurement',  // from v2.3 onwards
           ]
         },
         {
@@ -263,7 +263,7 @@ module.exports = {
             'apps/ios',
             'apps/windows',
             ['ecosystem/alexa/', 'Amazon Alexa'],
-            ['ecosystem/google-assistant/', 'Google Assistant'],
+            ['ecosystem/google-assistant/', 'Google Assistant'], // from v2.3 onwards
             ['../addons/integrations/homekit/', 'Apple HomeKit'],
             ['ecosystem/ifttt/', 'IFTTT'],
             ['ecosystem/mycroft/', 'Mycroft.AI'],
@@ -297,7 +297,7 @@ module.exports = {
             'developer/prerequisites/targetplatform',
             'developer/development/ide',
             'developer/development/guidelines',
-            'developer/development/conventions',
+            'developer/development/conventions', // from v2.3 onwards
             'developer/development/bindings',
             'developer/development/logging',
             'developer/development/evolution',

--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -22,5 +22,20 @@ export default ({
           }
         }
       })
+
+      // Add the cookie consent before </body>
+      let tag = document.createElement('script')
+      tag.setAttribute('type', 'text/javascript')
+      tag.setAttribute('id', 'cookieinfo')
+      tag.setAttribute('src', '/cookieinfo.min.js')
+      tag.setAttribute('data-bg', '#645862')
+      tag.setAttribute('data-fg', '#FFFFFF')
+      tag.setAttribute('data-link', '#F1D600')
+      tag.setAttribute('data-linkmsg', 'Privacy Policy')
+      tag.setAttribute('data-moreinfo', '/privacy.html')
+      tag.setAttribute('data-cookie', 'CookieInfoScript')
+      tag.setAttribute('data-text-align', 'left')
+      tag.setAttribute('data-close-text', 'Got it!')
+      document.body.appendChild(tag)
     }
   }

--- a/.vuepress/override.styl
+++ b/.vuepress/override.styl
@@ -106,7 +106,7 @@ div:not([class*='language-'])
         code
             color black
 
-a[href*='community.openhab.org'] .outbound
+a[href*='.openhab.org'] .outbound
         display none
 
 .nav-item > a.external:hover

--- a/prepare-docs.rb
+++ b/prepare-docs.rb
@@ -11,6 +11,13 @@ $docs_repo = "https://github.com/openhab/openhab-docs"
 $docs_repo_root = $docs_repo + "/blob/gh-pages"
 $esh_repo = "https://github.com/eclipse/smarthome"
 $esh_repo_root = $esh_repo + "/blob/master/docs/documentation"
+$version = nil
+
+if ENV["OH_DOCS_VERSION"] then
+    puts ">>> Generating docs for version #{ENV["OH_DOCS_VERSION"]}"
+    $version = ENV["OH_DOCS_VERSION"]
+    $version += ".0" if $version.split(".").length == 2
+end
 
 if (ARGV[0] && ARGV[0] == "--no-clone" && Dir.exists?(".vuepress/openhab-docs")) then
     puts ">>> Re-using existing clone"
@@ -19,7 +26,7 @@ else
     FileUtils.rm_rf(".vuepress/openhab-docs")
 
     puts ">>> Cloning openhab-docs"
-    `git clone --depth 1 https://github.com/openhab/openhab-docs .vuepress/openhab-docs`
+    `git clone --depth 1 #{$version ? "--branch #{$version}" : ""} https://github.com/openhab/openhab-docs .vuepress/openhab-docs`
 end
 
 $esh_features = []
@@ -60,6 +67,11 @@ def process_file(indir, file, outdir, source)
     obsolete_binding = false
     og_title = 'openHAB'
     og_description = 'a vendor and technology agnostic open source automation software for your home'
+
+    if !File.exists?("#{indir}/#{file}") then
+        puts "process_file: IGNORING (NON-EXISTING): #{indir}/#{file}"
+        return
+    end
 
     FileUtils.mkdir_p(outdir)
     File.open("#{outdir}/#{file}", "w+") { |out|
@@ -503,15 +515,16 @@ Dir.glob(".vuepress/openhab-docs/_addons_bindings/**") { |path|
 
 
 puts ">>> Creating ZWave thing viewer"
-File.open('addons/bindings/zwave/thing.md', 'w+') { |out|
-    out.puts '---'
-    out.puts 'title: ZWave Thing'
-    out.puts 'prev: ./'
-    out.puts '---'
-    out.puts
-    out.puts '<ThingDocRenderer />'
-}
-
+if (File.exists?('.vuepress/openhab-docs/_addons_bindings/zwave/doc/things.md')) then
+    File.open('addons/bindings/zwave/thing.md', 'w+') { |out|
+        out.puts '---'
+        out.puts 'title: ZWave Thing'
+        out.puts 'prev: ./'
+        out.puts '---'
+        out.puts
+        out.puts '<ThingDocRenderer />'
+    }
+end
 
 
 # puts ">>> Migrating Z-Wave docs"


### PR DESCRIPTION
- Fetch Open Sans fonts from Google again (it seems to work better)
- Add-on logos: handle non-root base
- prepare-docs & config.js: use OH_DOCS_VERSION environment variable
- Previous versions dropdown: add 2.3 and special handling when not the latest version.
- Add cookie banner in enhanceApp.js (This will prevent having to rely on Netlify to inject
the script before </body>)

Signed-off-by: Yannick Schaus <github@schaus.net>