### PR TITLE
Update macOS installation guide file from macosx to macos

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -206,7 +206,7 @@ module.exports = {
             'installation/',
             ['installation/linux', 'Linux'],
             ['installation/windows', 'Windows'],
-            ['installation/macosx', 'macOS'],
+            ['installation/macos', 'macOS'],
             'installation/openhabian',
             'installation/rasppi',
             'installation/pine',


### PR DESCRIPTION
See: https://github.com/openhab/openhab-docs/pull/778#discussion_r218461874

To be merged when https://github.com/openhab/openhab-docs/pull/778 is merged.

I think Jenkins will pick up this change and then uses it for generating the website?