### PR TITLE
Remove active page headers in sidebar

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -80,6 +80,8 @@ module.exports = {
     logo: `/openhab-logo.png`,
     // repo: 'openhab',
     editLinks: false,
+    activeHeaderLinks: false,
+    sidebarDepth: 0,
     docsDir: 'docs',
     algolia: {
       apiKey: 'af17a113c6a11af8057592a3120ffd3b',


### PR DESCRIPTION
Also disables the anchor in the URL following the "active" heading as the user scrolls down the page.

Resolves #45.
Resolves #116.