### PR TITLE
Simplify Docker installation instructions by using new multi-architecture tags

### DIFF
--- a/.vuepress/components/InstallInstructions.vue
+++ b/.vuepress/components/InstallInstructions.vue
@@ -133,7 +133,7 @@ usermod -a -G openhab myownuser
         -v openhab_userdata:/openhab/userdata \
         -d \
         --restart=always \
-        openhab/openhab:{{selectedVersion === 'stable' ? $page.frontmatter.currentVersion : selectedVersion === 'testing' ? $page.frontmatter.currentMilestoneVersion : $page.frontmatter.currentSnapshotVersion.toLowerCase()}}-amd64-debian
+        openhab/openhab:{{selectedVersion === 'stable' ? $page.frontmatter.currentVersion : selectedVersion === 'testing' ? $page.frontmatter.currentMilestoneVersion : $page.frontmatter.currentSnapshotVersion.toLowerCase()}}
 </code></pre>
         </div>
       </ol>


### PR DESCRIPTION
openhab/openhab-docker#213 introduced new tags allowing Docker to download architecture specific images. It also allows for using shorter tags.