### PR TITLE
#846 - updated docs for IFTTT integration with openHAB

### DIFF
--- a/docs/ecosystem/ifttt/readme.md
+++ b/docs/ecosystem/ifttt/readme.md
@@ -11,71 +11,49 @@ meta:
 
 # IFTTT Integration for openHAB
 
-<div class="img-wrapper"><img src='./images/ifttt-meets-openhab.jpg' alt='IFTTT meets openHAB'/></div>
+[If This Then That (IFTTT)](https://ifttt.com) is a very popular web-based service that allows users to create "applets", which can combine different web services into powerful automation rules. With its [hundreds of services](https://ifttt.com/services), there are limitless new creative options: Be notified through text-to-speech if you are receive a DM on twitter, be warned through your lights if your favorite stock price falls below a certain threshold or put your house in away-mode when you turn on the ignition of your car - you can get further inspiration by browsing through existing applets.
 
-openHAB users can take advantage of IFTTT to realize even more use cases in their smart home!
+openHAB users can take advantage of IFTTT to realize even more use cases in their smart home! 
 
-## What is IFTTT?
+Besides the new kinds of integration possibilities, IFTTT is also a good start for new openHAB users as it makes the creation of rules dead simple - no need to do any scripting, no complex setup routines, it all works through a few mouse clicks!
 
-[If This Then That (IFTTT)](https://ifttt.com) is a very popular web-based service that allows users to create "applets", which can combine different web services into powerful automation rules.
+insert here openHAB service logo from IFTTT.com
 
-## Why use openHAB with IFTTT?
+# Getting Started
 
-openHAB already integrates with [far more than 200 different smart home technologies](/addons). While there are some web services like Twitter available, this is not the primary integration focus of openHAB. Therefore IFTTT perfectly complements the features of openHAB: With its [hundreds of channels](https://ifttt.com/channels), there are limitless new creative options: Be notified through text-to-speech if you are receive a DM on twitter, be warned through your lights if your favorite stock price falls below a certain threshold or put your house in away-mode when you turn on the ignition of your car - you can get further inspiration by browsing through existing applets.
+## Requirements
+* [openHAB Cloud Connector](https://www.openhab.org/addons/integrations/openhabcloud/#openhab-cloud-connector) configured using [myopenHAB.org](https://myopenHAB.org)
+* [IFTTT](https://ifttt.com/join) account
 
-<div class="row da-thumbs">
-  <article class="span4 bloc">
-    <a href="https://ifttt.com/recipes/300800-update-my-presence-if-nest-says-i-m-back-home">
-      <section class="img-wrapper">
-        <img alt="" src="./images/ifttt1.png" style="-webkit-transform: scale(1);">
-      </section>
-    </a>
+## Configuration
 
-  <div class="da-animate da-slideFromTop" style="display: block;">
-    <span class="iconWrapper iconLink icon-search" style="font-style: italic; margin-top: 63px"></span>
-  </div></a>
+**1. Connect openHAB with IFTTT**
 
-  <h3>Update my presence if Nest says I'm back home.</h3>
-  </article>
+IFTTT is available to all our users through the myopenHAB service. Activating the integration is easy. Just log in to your IFTTT account and activate the [openHAB service](https://ifttt.com/openhab). You will be forwarded to the [myopenHAB.org website](http://www.myopenhab.org/) to authorize the IFTTT service connection. 
+You can delete the IFTTT authorization token in the myopenHAB Applications section at any time.
 
-  <article class="span4 bloc">
-    <a href="https://ifttt.com/recipes/297847-open-garage-when-i-turn-on-ignition">
-      <section class="img-wrapper">
-        <img alt="" src="./images/ifttt2.png" style="-webkit-transform: scale(1);">
-      </section>
-    </a>
+**2. Expose specific items to IFTTT**
 
-  <div class="da-animate da-slideFromLeft" style="display: block;">
-    <span class="iconWrapper iconLink icon-search" style="font-style: italic; margin-top: 63px"></span>
-  </div></a>
+Before you start creating IFTTT applets you need to make sure that you configured your local openHAB runtime to expose certain items to myopenHAB.org. Only those items will be visible to IFTTT. Read here [how to expose items to myopenHAB.org](https://www.openhab.org/addons/integrations/openhabcloud/#configuration). You will also be able to send commands to those items from IFTTT Applets. 
 
-  <h3>Open my garage when I turn on the ignition</h3>
-  </article>
+**Important:** Items will appear in myopenHAB and thus in IFTTT only after at least one state update has been received by myopenHAB.org from your local openHAB runtime. 
 
-  <article class="span4 bloc">
-    <a href="https://ifttt.com/recipes/299083-announce-finished-tasks-using-tts">
-      <section class="img-wrapper">
-        <img alt="" src="./images/ifttt3.png" style="-webkit-transform: scale(1);">
-      </section>
-    </a>
+This can be done by for instance creating a simple rule:
 
-  <div class="da-animate da-slideFromRight" style="display: block;">
-    <span class="iconWrapper iconLink icon-search" style="font-style: italic; margin-top: 63px"></span>
-  </div></a>
+```
+rule "Set initial values IFTTT items"
+when
+	System started
+then
+	createTimer(now.plusSeconds(160)) [|
+		logInfo("RULE", "Set initial values IFTTT items")
+		postUpdate(YourItem, 5)
+	]
+end
+```
+# Some Examples
 
-  <h3>Announce finished tasks through text-to-speech</h3>
-  </article>
-</div>
-
-Besides the new kinds of integration possibilities, IFTTT is also a perfect start for new openHAB users as it makes the creation of rules dead simple - no need to do any scripting, no complex setup routines, it all works through a few mouse clicks!
-
-<div class="img-wrapper"><img src='./images/ifttt-do.jpg' alt='IFTTT Do Button'/></div>
-
-We have also integrated with IFTTT’s [Do Button](https://ifttt.com/products/do/button). The Do button allows you to access often required functionality very quickly - either through the Do app, as a widget or even as a floating button, that is always present on your screen.
-
-## Let's Go!
-
-IFTTT is available to all our users through the [myopenHAB service](http://www.myopenhab.org/). Once you have your myopenHAB account set up, all you have to do is to decide, which items you want to share with IFTTT and to activate the openHAB channel.
+insert images of openHAB applets.
 
 
 <EditPageLink/>

--- a/docs/ecosystem/ifttt/readme.md
+++ b/docs/ecosystem/ifttt/readme.md
@@ -11,7 +11,8 @@ meta:
 
 # IFTTT Integration for openHAB
 
-[If This Then That (IFTTT)](https://ifttt.com) is a very popular web-based service that allows users to create "applets", which can combine different web services into powerful automation rules. With its [hundreds of services](https://ifttt.com/services), there are limitless new creative options: Be notified through text-to-speech if you are receive a DM on twitter, be warned through your lights if your favorite stock price falls below a certain threshold or put your house in away-mode when you turn on the ignition of your car - you can get further inspiration by browsing through existing applets.
+[If This Then That (IFTTT)](https://ifttt.com) is a very popular web-based service that allows users to create "applets", which can combine different web services into powerful automation rules. 
+With its [hundreds of services](https://ifttt.com/services), there are limitless new creative options: Be notified through text-to-speech if you are receive a DM on twitter, be warned through your lights if your favorite stock price falls below a certain threshold or put your house in away-mode when you turn on the ignition of your car - you can get further inspiration by browsing through existing applets.
 
 openHAB users can take advantage of IFTTT to realize even more use cases in their smart home! 
 
@@ -27,12 +28,18 @@ Besides the new kinds of integration possibilities, IFTTT is also a good start f
 
 **1. Connect openHAB with IFTTT**
 
-IFTTT is available to all our users through the myopenHAB service. Activating the integration is easy. Just log in to your IFTTT account and activate the [openHAB service](https://ifttt.com/openhab). You will be forwarded to the [myopenHAB.org website](http://www.myopenhab.org/) to authorize the IFTTT service connection. 
+IFTTT is available to all our users through the myopenHAB service. 
+Activating the integration is easy. 
+Just log in to your IFTTT account and activate the [openHAB service](https://ifttt.com/openhab). 
+You will be forwarded to the [myopenHAB.org website](http://www.myopenhab.org/) to authorize the IFTTT service connection. 
 You can delete the IFTTT authorization token in the myopenHAB Applications section at any time.
 
 **2. Expose specific items to IFTTT**
 
-Before you start creating IFTTT applets you need to make sure that you configured your local openHAB runtime to expose certain items to myopenHAB.org. Only those items will be visible to IFTTT. Read here [how to expose items to myopenHAB.org](https://www.openhab.org/addons/integrations/openhabcloud/#configuration). You will also be able to send commands to those items from IFTTT Applets. 
+Before you start creating IFTTT applets you need to make sure that you configured your local openHAB runtime to expose certain items to myopenHAB.org. 
+Only those items will be visible to IFTTT. 
+Read here [how to expose items to myopenHAB.org](https://www.openhab.org/addons/integrations/openhabcloud/#configuration). 
+You will also be able to send commands to those items from IFTTT Applets. 
 
 **Important:** Items will appear in myopenHAB and thus in IFTTT only after at least one state update has been received by myopenHAB.org from your local openHAB runtime. 
 
@@ -52,7 +59,8 @@ end
 
 **Sending notifications from openHAB to your mobile device via IFTTT**
 
-If you are using iOS or Android, you can use IFTTT to send notifications from your openHAB runtime to your device running iOS or Android. Read more about this [here](https://community.openhab.org/t/openhab-send-sensor-notification-to-ios-android-using-ifttt/24725).
+If you are using iOS or Android, you can use IFTTT to send notifications from your openHAB runtime to your device running iOS or Android. 
+Read more about this [here](https://community.openhab.org/t/openhab-send-sensor-notification-to-ios-android-using-ifttt/24725).
 
 
 <EditPageLink/>

--- a/docs/ecosystem/ifttt/readme.md
+++ b/docs/ecosystem/ifttt/readme.md
@@ -17,8 +17,6 @@ openHAB users can take advantage of IFTTT to realize even more use cases in thei
 
 Besides the new kinds of integration possibilities, IFTTT is also a good start for new openHAB users as it makes the creation of rules dead simple - no need to do any scripting, no complex setup routines, it all works through a few mouse clicks!
 
-insert here openHAB service logo from IFTTT.com
-
 # Getting Started
 
 ## Requirements
@@ -47,13 +45,14 @@ when
 then
 	createTimer(now.plusSeconds(160)) [|
 		logInfo("RULE", "Set initial values IFTTT items")
-		postUpdate(YourItem, 5)
+		postUpdate(YourItem, 0)
 	]
 end
 ```
-# Some Examples
 
-insert images of openHAB applets.
+**Sending notifications from openHAB to your mobile device via IFTTT**
+
+If you are using iOS or Android, you can use IFTTT to send notifications from your openHAB runtime to your device running iOS or Android. Read more about this [here](https://community.openhab.org/t/openhab-send-sensor-notification-to-ios-android-using-ifttt/24725).
 
 
 <EditPageLink/>


### PR DESCRIPTION
Addresses issue [#846](https://github.com/openhab/openhab-docs/issues/846
)

Some remarks:
- Removed information on DO button, as this was integrated into the core IFTTT app
- Changed channels to services and recipes to applets (new names from IFTTT)
- Updated links
- Removed outdated images containing old openHAB logo

Would like to add some images (one logo at the start) and some examples at the end, but not a clue how to do this.

Would appreciate input on this initial change