### PR TITLE
Copying the Rules JSON schemas to the openHAB website

### DIFF
--- a/.vuepress/public/schemas/ModuleTypes_schema.json
+++ b/.vuepress/public/schemas/ModuleTypes_schema.json
@@ -1,0 +1,1029 @@
+{
+	"$schema":"http://json-schema.org/draft-04/schema#",
+	"title":"Automation Module Type Definitions",
+	"description":"This schema is used for verification of JSON objects used for creation of Automation Module Types.",
+	"type":"object",
+	"additionalProperties":false,
+	"properties":{
+		"triggers":{
+			"type":"array",
+			"minItems":1,
+			"title":"Trigger Module Types",
+			"description":"Container for Trigger Module Types used to create the Trigger Modules of the Rule.",
+			"items":{
+				"type":"object",
+				"title":"Trigger Module Type",
+				"description":"Definition of the Trigger Module Type.",
+				"additionalProperties":false,
+				"required":[
+					"uid"
+				],
+				"properties":{
+					"uid":{
+						"type":"string",
+						"title":"Trigger UID",
+						"description":"Unique identifier of the Trigger Module Type.",
+						"pattern":"[A-Za-z0-9_-]*"
+					},
+					"visibility":{
+						"enum":[
+							"VISIBLE",
+							"HIDDEN",
+							"EXPERT"
+						],
+						"default":"VISIBLE",
+						"title":"Visibility",
+						"description":"Defines visibility of the Module Type."
+					},
+					"label":{
+						"type":"string",
+						"title":"Trigger Label",
+						"description":"Short(one word) user friendly description of the Trigger Module Type."
+					},
+					"description":{
+						"type":"string",
+						"title":"Trigger Description",
+						"description":"A brief description of what the Trigger is and for what it is used."
+					},
+					"tags":{
+						"type":"array",
+						"title":"Module Type Tags",
+						"description":"Non-hierarchical keywords or terms describing the Module Type. They help to classify the module types and allow them to be found.",
+						"minItems":1,
+						"items":{
+							"type":"string",
+							"title":"Tag",
+							"description":"Keyword or term describing the Module Type."
+						}
+					},
+					"configDescriptions":{
+						"type":"array",
+						"title":"Trigger Configuration Descriptor",
+						"description":"Used to describe the configuration parameters of the Trigger.",
+						"minItems":1,
+						"items":{
+							"type":"object",
+							"title":"Configuration Parameter Description",
+							"description":"Description of property for configuring the Module.",
+							"additionalProperties":false,
+							"required":[
+								"name",
+								"type"
+							],
+							"properties":{
+								"name":{
+									"pattern":"[A-Za-z0-9]+",
+									"type":"string",
+									"title":"Configuration Parameter Name",
+									"description":"Identifies uniquely the configuration parameter in scope of the Trigger Type(must neither be null nor empty)."
+								},
+								"type":{
+									"enum":[
+										"TEXT",
+										"INTEGER",
+										"DECIMAL",
+										"BOOLEAN"
+									],
+									"title":"Configuration Parameter Type",
+									"description":"Property declaring the data type of the configuration parameter."
+								},
+								"label":{
+									"type":"string",
+									"title":"Configuration Parameter Label",
+									"description":"A human understandable label of the Configuration Parameter."
+								},
+								"description":{
+									"type":"string",
+									"title":"Configuration Parameter Description",
+									"description":"A human understandable description of the Configuration Parameter."
+								},
+								"required":{
+									"type":"boolean",
+									"default":false,
+									"title":"Required Configuration Parameter",
+									"description":"Specifies whether the value is required."
+								},
+								"min":{
+									"type":"number",
+									"title":"Configuration Parameter Minimum Allowed Value",
+									"description":"The minimal value for numeric types, or the minimal length of strings, or the minimal number of selected options."
+								},
+								"max":{
+									"type":"number",
+									"title":"Configuration Parameter Maximum Allowed Value",
+									"description":"The maximal value for numeric types, or the maximal length of strings, or the maximal number of selected options."
+								},
+								"step":{
+									"type":"number",
+									"title":"Configuration Parameter Step",
+									"description":"The value granularity for a numeric value"
+								},
+								"pattern":{
+									"type":"string",
+									"title":"Configuration Parameter Pattern",
+									"description":"The regular expression for a text type."
+								},
+								"readOnly":{
+									"type":"boolean",
+									"default":false,
+									"title":"Readable Configuration Parameter",
+									"description":"Specifies whether the value is read-only."
+								},
+								"multiple":{
+									"type":"boolean",
+									"default":false,
+									"title":"Multiple Configuration Parameter",
+									"description":"Specifies whether multiple selections of options are allowed."
+								},
+								"multipleLimit":{
+									"type":"number",
+									"title":"Multiple Configuration Parameter Limit",
+									"description":"Specifies the maximum number of options that can be selected when multiple is true."
+								},
+								"context":{
+									"type":"string",
+									"title":"Configuration Parameter Context",
+									"description":"Serves to determine how to treat the value of the Configuration Parameter."
+								},
+								"default":{
+									"type":"string",
+									"title":"Configuration Parameter Default Value",
+									"description":"Declaring a default value for the Configuration Parameter if missing."
+								},
+								"unit":{
+									"type":"string",
+									"title":"Configuration Parameter Unit",
+									"description":"Specifies the unit of measurements for the configuration parameter."
+								},
+								"unitLabel":{
+									"type":"string",
+									"title":"Configuration Parameter Unit Label",
+									"description":"Specifies the unit label for the configuration parameter. This attribute can also be used to provide natural language units as iterations, runs, etc."
+								},
+								"filterCriteria":{
+									"type":"array",
+									"title":"Configuration Parameter Filter",
+									"description":"Criteria for dynamic selection of values.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"name",
+											"value"
+										],
+										"properties":{
+											"name":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"options":{
+									"type":"array",
+									"title":"Configuration Parameter Options",
+									"description":"List of definitions of the parameter for static selection.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"label",
+											"value"
+										],
+										"properties":{
+											"label":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"limitToOptions":{
+									"type":"boolean",
+									"default":false,
+									"title":"limit To Options",
+									"description":"Specifies that the users input is limited to the options list. When set to true without options, this should have no affect. When set to true with options, the user can only select the options from the list When set to false with options, the user can enter values other than those in the list."
+								},
+								"groupName":{
+									"type":"string",
+									"title":"Configuration Parameter Group Name",
+									"description":"A string used to group parameters together into logical blocks so that the UI can display them together."
+								},
+								"advanced":{
+									"type":"boolean",
+									"default":false,
+									"title":"An Advanced Configuration Parameter",
+									"description":"Specifies if this is an advanced parameter. An advanced parameter can be hidden in the UI to focus the user on important configuration."
+								}
+							}
+						}
+					},
+					"children":{
+						"type":"array",
+						"minItems":1,
+						"title":"Trigger Modules",
+						"description":"Contains definitions of the Trigger Modules of the Trigger Composition.",
+						"items":{
+							"type":"object",
+							"title":"Trigger Module",
+							"description":"Defines the fact which triggers the Rule execution.",
+							"additionalProperties":false,
+							"required":[
+								"id",
+								"type"
+							],
+							"properties":{
+								"id":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Trigger ID",
+									"description":"Identifies uniquely the Module in scope of the Composite Module Type."
+								},
+								"type":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Trigger Module Type UID",
+									"description":"Identifies the Module Type used for creation of the Trigger Module. Must be unique in scope of concrete Trigger Composition."
+								},
+								"configuration":{
+									"type":"object",
+									"title":"Trigger Configuration",
+									"description":"Used to define values for the configuration parameters of the Trigger Module."
+								},
+								"label":{
+									"type":"string",
+									"title":"Trigger Module Label",
+									"description":"A human understandable label of the Trigger Module."
+								},
+								"description":{
+									"type":"string",
+									"title":"Trigger Module Description",
+									"description":"A human understandable description of the Trigger Module."
+								}
+							}
+						}
+					},
+					"outputs":{
+						"type":"array",
+						"minItems":1,
+						"title":"Trigger Outputs",
+						"description":"Container for Trigger Outputs used to bring data to the other Modules of the Rule.",
+						"items":{
+							"type":"object",
+							"title":"Trigger Output",
+							"description":"Output object of the Trigger used to transfer data to other Modules of the Rule.",
+							"additionalProperties":false,
+							"required":[
+								"type",
+								"name"
+							],
+							"properties":{
+								"name":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*"
+								},
+								"type":{
+									"type":"string",
+									"description":"Fully qualified name of Java class or a human understandable text."
+								},
+								"label":{
+									"type":"string",
+									"description":"A human understandable label of the output"
+								},
+								"description":{
+									"type":"string",
+									"description":"A human understandable description of the output"
+								},
+								"defaultValue":{
+									"type":"string",
+									"description":"The value that will be used in case of missing dynamic output"
+								},
+								"reference":{
+									"type":"string",
+									"description":"Specifies what part of the given value will be used."
+								},
+								"tags":{
+									"type":"array",
+									"minItems":1,
+									"items":{
+										"type":"string",
+										"description":"A key word used for auto-mapping the output to available inputs. Shows how to be considered a given value."
+									},
+									"description":"Shows how to be considered a given value. For example, as a Temperature."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"conditions":{
+			"type":"array",
+			"minItems":1,
+			"title":"Condition Module Types",
+			"description":"Container for Condition Module Types used to create the Condition Modules of the Rule.",
+			"items":{
+				"type":"object",
+				"title":"Condition Module Type",
+				"description":"Definition of the Condition Module Type.",
+				"additionalProperties": false,
+				"required":[
+					"uid"
+				],
+				"properties":{
+					"uid":{
+						"type":"string",
+						"title":"Condition UID",
+						"description":"Unique identifier of the Condition Module Type.",
+						"pattern":"[A-Za-z0-9_-]*"
+					},
+					"visibility":{
+						"enum":[
+							"VISIBLE",
+							"HIDDEN",
+							"EXPERT"
+						],
+						"default":"VISIBLE",
+						"title":"Visibility",
+						"description":"Defines visibility of the Module Type."
+					},
+					"label":{
+						"type":"string",
+						"title":"Condition Label",
+						"description":"Short(one word) user friendly description of the Condition Module Type."
+					},
+					"description":{
+						"type":"string",
+						"title":"Condition Designation",
+						"description":"A brief description of what the Condition is and for what it is used."
+					},
+					"tags":{
+						"type":"array",
+						"title":"Module Type Tags",
+						"description":"Non-hierarchical keywords or terms describing the Module Type. They help to classify the module types and allow them to be found.",
+						"minItems":1,
+						"items":{
+							"type":"string",
+							"title":"Tag",
+							"description":"Keyword or term describing the Module Type."
+						}
+					},
+					"configDescriptions":{
+						"type":"array",
+						"title":"Condition Configuration Descriptor",
+						"description":"Used to describe the configuration parameters of the Condition.",
+						"minItems":1,
+						"items":{
+							"type":"object",
+							"title":"Configuration Parameter Description",
+							"description":"Describes the configuration Parameter for configuring the Module.",
+							"additionalProperties": false,
+							"required":[
+								"name",
+								"type"
+							],
+							"properties":{
+								"name":{
+									"pattern":"[A-Za-z0-9_-]*",
+									"type":"string",
+									"title":"Configuration Parameter Name",
+									"description":"Identifies uniquely the configuration parameter in scope of the Condition Type(must neither be null nor empty)."
+								},
+								"type":{
+									"enum":[
+										"TEXT",
+										"INTEGER",
+										"DECIMAL",
+										"BOOLEAN"
+									],
+									"title":"Configuration Parameter Type",
+									"description":"Property declaring the data type of the configuration parameter."
+								},
+								"label":{
+									"type":"string",
+									"title":"Configuration Parameter Label",
+									"description":"A human understandable label of the Configuration Parameter."
+								},
+								"description":{
+									"type":"string",
+									"title":"Configuration Parameter Description",
+									"description":"A human understandable description of the Configuration Parameter."
+								},
+								"required":{
+									"type":"boolean",
+									"default":false,
+									"title":"Required Configuration Parameter",
+									"description":"Specifies whether the value is required."
+								},
+								"min":{
+									"type":"number",
+									"title":"Configuration Parameter Minimum Allowed Value",
+									"description":"The minimal value for numeric types, or the minimal length of strings, or the minimal number of selected options."
+								},
+								"max":{
+									"type":"number",
+									"title":"Configuration Parameter Maximum Allowed Value",
+									"description":"The maximal value for numeric types, or the maximal length of strings, or the maximal number of selected options."
+								},
+								"step":{
+									"type":"number",
+									"title":"Configuration Parameter Step",
+									"description":"The value granularity for a numeric value"
+								},
+								"pattern":{
+									"type":"string",
+									"title":"Configuration Parameter Pattern",
+									"description":"The regular expression for a text type."
+								},
+								"readOnly":{
+									"type":"boolean",
+									"default":false,
+									"title":"Readable Configuration Parameter",
+									"description":"Specifies whether the value is read-only."
+								},
+								"multiple":{
+									"type":"boolean",
+									"default":false,
+									"title":"Multiple Configuration Parameter",
+									"description":"Specifies whether multiple selections of options are allowed."
+								},
+								"multipleLimit":{
+									"type":"number",
+									"title":"Multiple Configuration Parameter Limit",
+									"description":"Specifies the maximum number of options that can be selected when multiple is true."
+								},
+								"context":{
+									"type":"string",
+									"title":"Configuration Parameter Context",
+									"description":"Serves to determine how to treat the value of the Configuration Parameter."
+								},
+								"default":{
+									"type":"string",
+									"title":"Configuration Parameter Default Value",
+									"description":"Declaring a default value for the Configuration Parameter if missing."
+								},
+								"unit":{
+									"type":"string",
+									"title":"Configuration Parameter Unit",
+									"description":"Specifies the unit of measurements for the configuration parameter."
+								},
+								"unitLabel":{
+									"type":"string",
+									"title":"Configuration Parameter Unit Label",
+									"description":"Specifies the unit label for the configuration parameter. This attribute can also be used to provide natural language units as iterations, runs, etc."
+								},
+								"filterCriteria":{
+									"type":"array",
+									"title":"Configuration Parameter Filter",
+									"description":"Criteria for dynamic selection of values.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"name",
+											"value"
+										],
+										"properties":{
+											"name":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"options":{
+									"type":"array",
+									"title":"Configuration Parameter Options",
+									"description":"List of definitions of the parameter for static selection.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"label",
+											"value"
+										],
+										"properties":{
+											"label":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"limitToOptions":{
+									"type":"boolean",
+									"default":false,
+									"title":"limit To Options",
+									"description":"Specifies that the users input is limited to the options list. When set to true without options, this should have no affect. When set to true with options, the user can only select the options from the list When set to false with options, the user can enter values other than those in the list."
+								},
+								"groupName":{
+									"type":"string",
+									"title":"Configuration Parameter Group Name",
+									"description":"A string used to group parameters together into logical blocks so that the UI can display them together."
+								},
+								"advanced":{
+									"type":"boolean",
+									"default":false,
+									"title":"An Advanced Configuration Parameter",
+									"description":"Specifies if this is an advanced parameter. An advanced parameter can be hidden in the UI to focus the user on important configuration."
+								}
+							}
+						}
+					},
+					"children":{
+						"type":"array",
+						"minItems":1,
+						"title":"Condition Modules",
+						"description":"Contains definitions of the Condition Modules of the Condition Composition.",
+						"items":{
+							"type":"object",
+							"title":"Condition Module",
+							"description":"A brief description of what the Condition is and for what it is used.",
+							"additionalProperties":false,
+							"required":[
+								"id",
+								"type"
+							],
+							"properties":{
+								"id":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Condition uid",
+									"description":"Identifies uniquely the Module in scope of the Rule."
+								},
+								"label":{
+									"type":"string",
+									"title":"Condition Label",
+									"description":"Short (one word) user friendly name of the Module."
+								},
+								"description":{
+									"type":"string",
+									"title":"Condition Description",
+									"description":"A brief description of what the Condition is and for what it is used."
+								},
+								"type":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Condition Module Type UID",
+									"description":"Identifies the Module Type used for creation of the Condition."
+								},
+								"configuration":{
+									"type":"object",
+									"title":"Condition Configuration",
+									"description":"Used to define values of the configuration parameters of the Condition."
+								},
+								"inputs":{
+									"type":"object",
+									"title":"Condition Input",
+									"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+								}
+							}
+						}
+					},
+					"inputs":{
+						"type":"array",
+						"minItems":1,
+						"title":"Condition Inputs",
+						"description":"Container for Condition Inputs used to get data from the Trigger Modules of the Rule.",
+						"items":{
+							"type":"object",
+							"title":"Condition Input",
+							"description":"Input object of the Condition used for binding an Output objects of other modules in order to receive data.",
+							"additionalProperties":false,
+							"required":[
+								"type",
+								"name"
+							],
+							"properties":{
+								"name":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*"
+								},
+								"type":{
+									"type":"string",
+									"description":"Fully qualified name of Java class or a human understandable text."
+								},
+								"label":{
+									"type":"string",
+									"description":"A human understandable label of the input"
+								},
+								"defaultValue":{
+									"type":"string",
+									"description":"The value that will be used in case of missing dynamic input"
+								},
+								"description":{
+									"type":"string",
+									"description":"A human understandable description of the input"
+								},
+								"tags":{
+									"type": "array",
+									"minItems":1,
+									"items":{
+										"type":"string",
+										"description":"A key word used for auto-mapping the input to available outputs. Shows how to be considered a given value."
+									},
+									"description":"Shows how to be considered a given value. For example, as a Temperature."
+								},
+								"required":{
+									"type":"boolean",
+									"description":"Shows how to be treated the given default value - be used in case of missing dynamic input or not."
+								},
+								"reference":{
+									"type":"string",
+									"description":"Specifies what part of the given value will be used."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"actions":{
+			"type":"array",
+			"minItems":1,
+			"title":"Action Module Types",
+			"description":"Container for Action Module Types used to create the Action Modules of the Rule.",
+			"items":{
+				"type":"object",
+				"title":"Action Module Type",
+				"description":"Definition of the Action Module Type.",
+				"additionalProperties":false,
+				"required":[
+					"uid"
+				],
+				"properties":{
+					"uid":{
+						"type":"string",
+						"title":"Action UID",
+						"description":"Unique identifier of the Action Module Type.",
+						"pattern":"[A-Za-z0-9_-]*"
+					},
+					"visibility":{
+						"enum":[
+							"VISIBLE",
+							"HIDDEN",
+							"EXPERT"
+						],
+						"default":"VISIBLE",
+						"title":"Visibility",
+						"description":"Defines visibility of Module Type."
+					},
+					"label":{
+						"type":"string",
+						"title":"Action Label",
+						"description":"Short(one word) user friendly description of the Action Module Type."
+					},
+					"description":{
+						"type":"string",
+						"title":"Action Designation",
+						"description":"A brief description of what the Action is and for what it is used."
+					},
+					"tags":{
+						"type":"array",
+						"title":"Module Type Tags",
+						"description":"Non-hierarchical keywords or terms describing the Module Type. They help to classify the module types and allow them to be found.",
+						"minItems":1,
+						"items":{
+							"type":"string"
+						}
+					},
+					"configDescriptions":{
+						"type":"array",
+						"title":"Action Configuration Descriptor",
+						"description":"Used to describe the configuration parameters of the Action.",
+						"minItems":1,
+						"items":{
+							"type":"object",
+							"title":"Configuration Parameter Description",
+							"description":"Describes the Configuration Parameter for configuring the Module.",
+							"additionalProperties":false,
+							"required":[
+								"name",
+								"type"
+							],
+							"properties":{
+								"name":{
+									"pattern":"[A-Za-z0-9_-]*",
+									"type":"string",
+									"title":"Configuration Parameter Name",
+									"description":"Identifies uniquely the configuration parameter in scope of the Action Type(must neither be null nor empty)."
+								},
+								"type":{
+									"enum":[
+										"TEXT",
+										"INTEGER",
+										"DECIMAL",
+										"BOOLEAN"
+									],
+									"title":"Configuration Parameter Type",
+									"description":"Property declaring the data type of the configuration parameter."
+								},
+								"label":{
+									"type":"string",
+									"title":"Configuration Parameter Label",
+									"description":"A human understandable label of the Configuration Parameter."
+								},
+								"description":{
+									"type":"string",
+									"title":"Configuration Parameter Description",
+									"description":"A human understandable description of the Configuration Parameter."
+								},
+								"required":{
+									"type":"boolean",
+									"default":false,
+									"title":"Required Configuration Parameter",
+									"description":"Specifies whether the value is required."
+								},
+								"min":{
+									"type":"number",
+									"title":"Configuration Parameter Minimum Allowed Value",
+									"description":"The minimal value for numeric types, or the minimal length of strings, or the minimal number of selected options."
+								},
+								"max":{
+									"type":"number",
+									"title":"Configuration Parameter Maximum Allowed Value",
+									"description":"The maximal value for numeric types, or the maximal length of strings, or the maximal number of selected options."
+								},
+								"step":{
+									"type":"number",
+									"title":"Configuration Parameter Step",
+									"description":"The value granularity for a numeric value"
+								},
+								"pattern":{
+									"type":"string",
+									"title":"Configuration Parameter Pattern",
+									"description":"The regular expression for a text type."
+								},
+								"readOnly":{
+									"type":"boolean",
+									"default":false,
+									"title":"Readable Configuration Parameter",
+									"description":"Specifies whether the value is read-only."
+								},
+								"multiple":{
+									"type":"boolean",
+									"default":false,
+									"title":"Multiple Configuration Parameter",
+									"description":"Specifies whether multiple selections of options are allowed."
+								},
+								"multipleLimit":{
+									"type":"number",
+									"title":"Multiple Configuration Parameter Limit",
+									"description":"Specifies the maximum number of options that can be selected when multiple is true."
+								},
+								"context":{
+									"type":"string",
+									"title":"Configuration Parameter Context",
+									"description":"Serves to determine how to treat the value of the Configuration Parameter."
+								},
+								"default":{
+									"type":"string",
+									"title":"Configuration Parameter Default Value",
+									"description":"Declaring a default value for the Configuration Parameter if missing."
+								},
+								"unit":{
+									"type":"string",
+									"title":"Configuration Parameter Unit",
+									"description":"Specifies the unit of measurements for the configuration parameter."
+								},
+								"unitLabel":{
+									"type":"string",
+									"title":"Configuration Parameter Unit Label",
+									"description":"Specifies the unit label for the configuration parameter. This attribute can also be used to provide natural language units as iterations, runs, etc."
+								},
+								"filterCriteria":{
+									"type":"array",
+									"title":"Configuration Parameter Filter",
+									"description":"Criteria for dynamic selection of values.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"name",
+											"value"
+										],
+										"properties":{
+											"name":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"options":{
+									"type":"array",
+									"title":"Configuration Parameter Options",
+									"description":"List of definitions of the parameter for static selection.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"label",
+											"value"
+										],
+										"properties":{
+											"label":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"limitToOptions":{
+									"type":"boolean",
+									"default":false,
+									"title":"limit To Options",
+									"description":"Specifies that the users input is limited to the options list. When set to true without options, this should have no affect. When set to true with options, the user can only select the options from the list When set to false with options, the user can enter values other than those in the list."
+								},
+								"groupName":{
+									"type":"string",
+									"title":"Configuration Parameter Group Name",
+									"description":"A string used to group parameters together into logical blocks so that the UI can display them together."
+								},
+								"advanced":{
+									"type":"boolean",
+									"default":false,
+									"title":"An Advanced Configuration Parameter",
+									"description":"Specifies if this is an advanced parameter. An advanced parameter can be hidden in the UI to focus the user on important configuration."
+								}
+							}
+						}
+					},
+					"children":{
+						"type":"array",
+						"minItems":1,
+						"title":"Action Modules",
+						"description":"Contains definitions of the Action Modules of the Action Composition.",
+						"items":{
+							"type":"object",
+							"title":"Action Module",
+							"description":"A brief description of what the Action is and for what it is used.",
+							"additionalProperties":false,
+							"required":[
+								"id",
+								"type"
+							],
+							"properties":{
+								"id":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Action ID",
+									"description":"Identifies uniquely the Module in scope of the Rule."
+								},
+								"label":{
+									"type":"string",
+									"title":"Action Label",
+									"description":"Short (one word) user friendly name of the Module."
+								},
+								"description":{
+									"type":"string",
+									"title":"Action Description",
+									"description":"A brief description of what the Action is and for what it is used."
+								},
+								"type":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Action Module Type UID",
+									"description":"Identifies the Module Type used for creation of the Action."
+								},
+								"configuration":{
+									"type":"object",
+									"title":"Action Configuration",
+									"description":"Used to define values of the configuration parameters of the Action."
+								},
+								"inputs":{
+									"type":"object",
+									"title":"Action Input",
+									"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+								},
+								"outputs":{
+									"type":"object",
+									"title":"Action Output",
+									"description":"Contains pairs of Output Name and Output reference. The reference defines what part of a complex data has to be used as value of this output."
+								}
+							}
+						}
+					},
+					"inputs":{
+						"type":"array",
+						"minItems":1,
+						"title":"Action Inputs",
+						"description":"Container for Action Inputs used to get data from the other Modules of the Rule.",
+						"items":{
+							"type":"object",
+							"title":"Action Input",
+							"description":"Input object of the Action used for binding an Output objects of other modules in order to receive data.",
+							"additionalProperties":false,
+							"required":[
+								"type",
+								"name"
+							],
+							"properties":{
+								"name":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*"
+								},
+								"type":{
+									"type":"string",
+									"description":"Fully qualified name of Java class or a human understandable text."
+								},
+								"label":{
+									"type":"string",
+									"description":"A human understandable label of the input"
+								},
+								"defaultValue":{
+									"type":"string",
+									"description":"The value that will be used in case of missing dynamic input"
+								},
+								"description":{
+									"type":"string",
+									"description":"A human understandable description of the input"
+								},
+								"tags":{
+									"type":"array",
+									"minItems":1,
+									"items":{
+										"type":"string",
+										"description":"A key word used for auto-mapping the input to available outputs. Shows how to be considered a given value."
+									},
+									"description":"Shows how to be considered a given value. For example, as a Temperature."
+								},
+								"required":{
+									"type":"boolean",
+									"description":"Shows how to be treated the given default value - be used in case of missing dynamic input or not."
+								},
+								"reference":{
+									"type":"string",
+									"description":"Specifies what part of the given value will be used."
+								}
+							}
+						}
+					},
+					"outputs":{
+						"type":"array",
+						"minItems":1,
+						"title":"Action Outputs",
+						"description":"Container for Action Outputs used to bring data to the other Action Modules of the Rule.",
+						"items":{
+							"type":"object",
+							"title":"Action Output",
+							"description":"Output object of the Action used to transfer data to other Action Modules of the Rule.",
+							"additionalProperties":false,
+							"required":[
+								"type",
+								"name"
+							],
+							"properties":{
+								"name":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*"
+								},
+								"type":{
+									"type":"string",
+									"description":"Fully qualified name of Java class or a human understandable text."
+								},
+								"label":{
+									"type":"string",
+									"description":"A human understandable label of the output"
+								},
+								"description":{
+									"type":"string",
+									"description":"A human understandable description of the output"
+								},
+								"defaultValue":{
+									"type":"string",
+									"description":"The value that will be used in case of missing dynamic output"
+								},
+								"reference":{
+									"type":"string",
+									"description":"Specifies what part of the given value will be used."
+								},
+								"tags":{
+									"type":"array",
+									"minItems":1,
+									"items":{
+										"type":"string",
+										"description":"A key word used for auto-mapping the output to available inputs. Shows how to be considered a given value."
+									},
+									"description":"Shows how to be considered a given value. For example, as a Temperature."
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/.vuepress/public/schemas/Rules_schema.json
+++ b/.vuepress/public/schemas/Rules_schema.json
@@ -1,0 +1,873 @@
+{
+	"$schema":"http://json-schema.org/draft-04/schema#",
+	"title":"Automation Rule Definitions",
+	"description":"This schema is used for verification of JSON objects used for creation of Automation Rule Objects.",
+		"oneOf":[
+			{
+				"type":"object",
+				"title":"Rule",
+				"description":"Rule Definition",
+				"additionalProperties":false,
+				"required":[
+					"triggers",
+					"actions"
+				],
+				"properties":{
+					"name":{
+						"type":"string",
+						"title":"Rule name",
+						"description":"Short (one word) user friendly name of the Rule."
+					},
+					"uid":{
+						"type":"string",
+						"pattern":"[A-Za-z0-9_-]*",
+						"title":"Rule UID",
+						"description":"An unique identifier of the Rule in scope of the Rule Engine."
+					},
+					"tags":{
+						"type":"array",
+						"title":"Rule Tags",
+						"description":"Non-hierarchical keywords or terms describing the Rule. They help to classify the rules and allow them to be found.",
+						"minItems":1,
+						"items":{
+							"type":"string",
+							"title":"Tag",
+							"description":"Keyword or term describing the Rule."
+						}
+					},
+					"description":{
+						"type":"string",
+						"title":"Rule Description",
+						"description":"A brief description of what the rule is and for what it is used."
+					},
+					"visibility":{
+						"enum":[
+							"VISIBLE",
+							"HIDDEN",
+							"EXPERT"
+						],
+						"default":"VISIBLE",
+						"title":"Visibility",
+						"description":"Defines visibility of the Rule."
+					},
+					"configDescriptions":{
+						"type":"array",
+						"title":"Rule Configuration Descriptor",
+						"description":"Used to describe the configuration parameters of the Rule.",
+						"minItems":1,
+						"items":{
+							"type":"object",
+							"title":"Configuration Property Description",
+							"description":"Description of property for configuring the Rule.",
+							"additionalProperties":false,
+							"required":[
+								"name",
+								"type"
+							],
+							"properties":{
+								"name":{
+									"pattern":"[A-Za-z0-9_-]*",
+									"type":"string",
+									"title":"Configuration Parameter Name",
+									"description":"Identifies uniquely the configuration parameter in scope of the Rule."
+								},
+								"type":{
+									"enum":[
+										"TEXT",
+										"INTEGER",
+										"DECIMAL",
+										"BOOLEAN"
+									],
+									"title":"Configuration Parameter Type",
+									"description":"Property declaring the data type of the configuration parameter."
+								},
+								"label":{
+									"type":"string",
+									"title":"Configuration Parameter Label",
+									"description":"A human understandable label of the Configuration Parameter."
+								},
+								"description":{
+									"type":"string",
+									"title":"Configuration Parameter Description",
+									"description":"A human understandable description of the Configuration Parameter."
+								},
+								"required":{
+									"type":"boolean",
+									"default":false,
+									"title":"Required Configuration Parameter",
+									"description":"Specifies whether the value is required."
+								},
+								"min":{
+									"type":"number",
+									"title":"Configuration Parameter Minimum Allowed Value",
+									"description":"The minimal value for numeric types, or the minimal length of strings, or the minimal number of selected options."
+								},
+								"max":{
+									"type":"number",
+									"title":"Configuration Parameter Maximum Allowed Value",
+									"description":"The maximal value for numeric types, or the maximal length of strings, or the maximal number of selected options."
+								},
+								"step":{
+									"type":"number",
+									"title":"Configuration Parameter Step",
+									"description":"The value granularity for a numeric value"
+								},
+								"pattern":{
+									"type":"string",
+									"title":"Configuration Parameter Pattern",
+									"description":"The regular expression for a text type."
+								},
+								"readOnly":{
+									"type":"boolean",
+									"default":false,
+									"title":"Readable Configuration Parameter",
+									"description":"Specifies whether the value is read-only."
+								},
+								"multiple":{
+									"type":"boolean",
+									"default":false,
+									"title":"Multiple Configuration Parameter",
+									"description":"Specifies whether multiple selections of options are allowed."
+								},
+								"multipleLimit":{
+									"type":"number",
+									"title":"Multiple Configuration Parameter Limit",
+									"description":"Specifies the maximum number of options that can be selected when multiple is true."
+								},
+								"context":{
+									"type":"string",
+									"title":"Configuration Parameter Context",
+									"description":"Serves to determine how to treat the value of the Configuration Parameter."
+								},
+								"default":{
+									"type":"string",
+									"title":"Configuration Parameter Default Value",
+									"description":"Declaring a default value for the Configuration Parameter if missing."
+								},
+								"unit":{
+									"type":"string",
+									"title":"Configuration Parameter Unit",
+									"description":"Specifies the unit of measurements for the configuration parameter."
+								},
+								"unitLabel":{
+									"type":"string",
+									"title":"Configuration Parameter Unit Label",
+									"description":"Specifies the unit label for the configuration parameter. This attribute can also be used to provide natural language units as iterations, runs, etc."
+								},
+								"filterCriteria":{
+									"type":"array",
+									"title":"Configuration Parameter Filter",
+									"description":"Criteria for dynamic selection of values.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"name",
+											"value"
+										],
+										"properties":{
+											"name":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"options":{
+									"type":"array",
+									"title":"Configuration Parameter Options",
+									"description":"List of definitions of the parameter for static selection.",
+									"items":{
+										"type":"object",
+										"additionalProperties":false,
+										"required":[
+											"label",
+											"value"
+										],
+										"properties":{
+											"label":{
+												"type":"string"
+											},
+											"value":{
+												"type":"string"
+											}
+										}
+									}
+								},
+								"limitToOptions":{
+									"type":"boolean",
+									"default":false,
+									"title":"limit To Options",
+									"description":"Specifies that the users input is limited to the options list. When set to true without options, this should have no affect. When set to true with options, the user can only select the options from the list When set to false with options, the user can enter values other than those in the list."
+								},
+								"groupName":{
+									"type":"string",
+									"title":"Configuration Parameter Group Name",
+									"description":"A string used to group parameters together into logical blocks so that the UI can display them together."
+								},
+								"advanced":{
+									"type":"boolean",
+									"default":false,
+									"title":"An Advanced Configuration Parameter",
+									"description":"Specifies if this is an advanced parameter. An advanced parameter can be hidden in the UI to focus the user on important configuration."
+								}
+							}
+						}
+					},
+					"configuration":{
+						"type":"object",
+						"title":"Rule Configuration",
+						"description":"Used to define values of the configuration parameters of the Rule."
+					},
+					"triggers":{
+						"type":"array",
+						"minItems":1,
+						"title":"Trigger Modules",
+						"description":"Contains definitions of the Trigger Modules of the Rule.",
+						"items":{
+							"type":"object",
+							"title":"Trigger Module",
+							"description":"Defines the fact which triggers the Rule execution.",
+							"additionalProperties":false,
+							"required":[
+								"id",
+								"type"
+							],
+							"properties":{
+								"id":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Trigger ID",
+									"description":"Identifies uniquely the Module in scope of the Rule."
+								},
+								"label":{
+									"type":"string",
+									"title":"Trigger Label",
+									"description":"Short (one word) user friendly name of the Module."
+								},
+								"description":{
+									"type":"string",
+									"title":"Trigger Description",
+									"description":"A brief description of what the Trigger is and for what it is used."
+								},
+								"type":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Trigger Module Type UID",
+									"description":"Identifies the Module Type used for creation of the Trigger Module."
+								},
+								"configuration":{
+									"type":"object",
+									"title":"Trigger Configuration",
+									"description":"Used to define values of the configuration parameters of the Trigger Module."
+								}
+							}
+						}
+					},
+					"conditions":{
+						"type":"array",
+						"minItems":1,
+						"title":"Condition Modules",
+						"description":"Contains definitions of Condition Modules of the Rule.",
+						"items":{
+							"type":"object",
+							"title":"Condition Module",
+							"description":"Defines the condition which permit to proceed with the Rule execution.",
+							"additionalProperties":false,
+							"required":[
+								"id",
+								"type"
+							],
+							"properties":{
+								"id":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Condition uid",
+									"description":"Identifies uniquely the Module in scope of the Rule."
+								},
+								"label":{
+									"type":"string",
+									"title":"Condition Label",
+									"description":"Short (one word) user friendly name of the Module."
+								},
+								"description":{
+									"type":"string",
+									"title":"Condition Description",
+									"description":"A brief description of what the Condition is and for what it is used."
+								},
+								"type":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Condition Module Type UID",
+									"description":"Identifies the Module Type used for creation of the Condition."
+								},
+								"configuration":{
+									"type":"object",
+									"title":"Condition Configuration",
+									"description":"Used to define values of the configuration parameters of the Condition."
+								},
+								"inputs":{
+									"type":"object",
+									"title":"Condition Input",
+									"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+								}
+							}
+						}
+					},
+					"actions":{
+						"type":"array",
+						"minItems":1,
+						"title":"Action Modules",
+						"description":"Contains definitions of Action Modules of the Rule.",
+						"items":{
+							"type":"object",
+							"title":"Action Module",
+							"description":"Defines an Action which has to be executed by the Rule.",
+							"additionalProperties":false,
+							"required":[
+								"id",
+								"type"
+							],
+							"properties":{
+								"id":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Action ID",
+									"description":"Identifies uniquely the Module in scope of the Rule."
+								},
+								"label":{
+									"type":"string",
+									"title":"Action Label",
+									"description":"Short (one word) user friendly name of the Module."
+								},
+								"description":{
+									"type":"string",
+									"title":"Action Description",
+									"description":"A brief description of what the Action is and for what it is used."
+								},
+								"type":{
+									"type":"string",
+									"pattern":"[A-Za-z0-9_-]*",
+									"title":"Action Module Type UID",
+									"description":"Identifies the Module Type used for creation of the Action."
+								},
+								"configuration":{
+									"type":"object",
+									"title":"Action Configuration",
+									"description":"Used to define values of the configuration parameters of the Action."
+								},
+								"inputs":{
+									"type":"object",
+									"title":"Action Input",
+									"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+								},
+								"outputs":{
+									"type":"object",
+									"title":"Action Output",
+									"description":"Contains pairs of Output Name and Output reference. The reference defines what part of a complex data has to be used as value of this output."
+								}
+							}
+						}
+					}
+				}
+			},
+			{
+				"type":"object",
+				"title":"Rule",
+				"description":"Rule Definition",
+				"additionalProperties":false,
+				"required":[
+					"template.uid"
+				],
+				"properties":{
+					"name":{
+						"type":"string",
+						"title":"Rule name",
+						"description":"Short (one word) user friendly name of the Rule."
+					},
+					"uid":{
+						"type":"string",
+						"pattern":"[A-Za-z0-9_-]*",
+						"title":"Rule uid",
+						"description":"An unique identifier of the Rule in scope of the Rule Engine."
+					},
+					"template.uid":{
+						"type":"string",
+						"pattern":"[A-Za-z0-9_-]*",
+						"title":"Rule Template UID",
+						"description":"Used for description of the Rule. It must be unique in scope of Template Registry."
+					},
+					"tags":{
+						"type":"array",
+						"title":"Rule Tags",
+						"description":"Non-hierarchical keywords or terms describing the Rule. They help to classify the rules and allow them to be found.",
+						"minItems":1,
+						"items":{
+							"type":"string",
+							"title":"Tag",
+							"description":"Keyword or term describing the Rule."
+						}
+					},
+					"description":{
+						"type":"string",
+						"title":"Rule Description",
+						"description":"A brief description of what the rule is and for what it is used."
+					},
+					"configuration":{
+						"type":"object",
+						"title":"Rule Configuration",
+						"description":"Used to define values of the configuration parameters of the Rule."
+					},
+					"visibility":{
+						"enum":[
+							"VISIBLE",
+							"HIDDEN",
+							"EXPERT"
+						],
+						"default":"VISIBLE",
+						"title":"Visibility",
+						"description":"Defines visibility of the Rule."
+					}
+				}
+			},
+			{
+				"type":"array",
+				"minItems":1,
+				"items":{
+					"oneOf":[
+						{
+							"type":"object",
+							"title":"Rule",
+							"description":"Rule Definition",
+							"additionalProperties":false,
+							"required":[
+								"triggers",
+								"actions"
+							],
+							"properties":{
+							"name":{
+								"type":"string",
+								"title":"Rule name",
+								"description":"Short (one word) user friendly name of the Rule."
+							},
+							"uid":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Rule UID",
+								"description":"An unique identifier of the Rule in scope of the Rule Engine."
+							},
+							"tags":{
+								"type":"array",
+								"title":"Rule Tags",
+								"description":"Non-hierarchical keywords or terms describing the Rule. They help to classify the rules and allow them to be found.",
+								"minItems":1,
+								"items":{
+									"type":"string",
+									"title":"Tag",
+									"description":"Keyword or term describing the Rule."
+								}
+							},
+							"description":{
+								"type":"string",
+								"title":"Rule Description",
+								"description":"A brief description of what the rule is and for what it is used."
+							},
+							"visibility":{
+								"enum":[
+									"VISIBLE",
+									"HIDDEN",
+									"EXPERT"
+								],
+								"default":"VISIBLE",
+								"title":"Visibility",
+								"description":"Defines visibility of the Rule."
+							},
+							"configDescriptions":{
+								"type":"array",
+								"title":"Rule Configuration Descriptor",
+								"description":"Used to describe the configuration parameters of the Rule.",
+								"minItems":1,
+								"items":{
+									"type":"object",
+									"title":"Configuration Property Description",
+									"description":"Description of property for configuring the Rule.",
+									"additionalProperties":false,
+									"required":[
+										"name",
+										"type"
+									],
+									"properties":{
+										"name":{
+											"pattern":"[A-Za-z0-9_-]*",
+											"type":"string",
+											"title":"Configuration Parameter Name",
+											"description":"Identifies uniquely the configuration parameter in scope of the Rule."
+										},
+										"type":{
+											"enum":[
+												"TEXT",
+												"INTEGER",
+												"DECIMAL",
+												"BOOLEAN"
+											],
+											"title":"Configuration Parameter Type",
+											"description":"Property declaring the data type of the configuration parameter."
+										},
+										"label":{
+											"type":"string",
+											"title":"Configuration Parameter Label",
+											"description":"A human understandable label of the Configuration Parameter."
+										},
+										"description":{
+											"type":"string",
+											"title":"Configuration Parameter Description",
+											"description":"A human understandable description of the Configuration Parameter."
+										},
+										"required":{
+											"type":"boolean",
+											"default":false,
+											"title":"Required Configuration Parameter",
+											"description":"Specifies whether the value is required."
+										},
+										"min":{
+											"type":"number",
+											"title":"Configuration Parameter Minimum Allowed Value",
+											"description":"The minimal value for numeric types, or the minimal length of strings, or the minimal number of selected options."
+										},
+										"max":{
+											"type":"number",
+											"title":"Configuration Parameter Maximum Allowed Value",
+											"description":"The maximal value for numeric types, or the maximal length of strings, or the maximal number of selected options."
+										},
+										"step":{
+											"type":"number",
+											"title":"Configuration Parameter Step",
+											"description":"The value granularity for a numeric value"
+										},
+										"pattern":{
+											"type":"string",
+											"title":"Configuration Parameter Pattern",
+											"description":"The regular expression for a text type."
+										},
+										"readOnly":{
+											"type":"boolean",
+											"default":false,
+											"title":"Readable Configuration Parameter",
+											"description":"Specifies whether the value is read-only."
+										},
+										"multiple":{
+											"type":"boolean",
+											"default":false,
+											"title":"Multiple Configuration Parameter",
+											"description":"Specifies whether multiple selections of options are allowed."
+										},
+										"multipleLimit":{
+											"type":"number",
+											"title":"Multiple Configuration Parameter Limit",
+											"description":"Specifies the maximum number of options that can be selected when multiple is true."
+										},
+										"context":{
+											"type":"string",
+											"title":"Configuration Parameter Context",
+											"description":"Serves to determine how to treat the value of the Configuration Parameter."
+										},
+										"default":{
+											"type":"string",
+											"title":"Configuration Parameter Default Value",
+											"description":"Declaring a default value for the Configuration Parameter if missing."
+										},
+										"unit":{
+											"type":"string",
+											"title":"Configuration Parameter Unit",
+											"description":"Specifies the unit of measurements for the configuration parameter."
+										},
+										"unitLabel":{
+											"type":"string",
+											"title":"Configuration Parameter Unit Label",
+											"description":"Specifies the unit label for the configuration parameter. This attribute can also be used to provide natural language units as iterations, runs, etc."
+										},
+										"filterCriteria":{
+											"type":"array",
+											"title":"Configuration Parameter Filter",
+											"description":"Criteria for dynamic selection of values.",
+											"items":{
+												"type":"object",
+												"additionalProperties":false,
+												"required":[
+													"name",
+													"value"
+												],
+												"properties":{
+													"name":{
+														"type":"string"
+													},
+													"value":{
+														"type":"string"
+													}
+												}
+											}
+										},
+										"options":{
+											"type":"array",
+											"title":"Configuration Parameter Options",
+											"description":"List of definitions of the parameter for static selection.",
+											"items":{
+												"type":"object",
+												"additionalProperties":false,
+												"required":[
+													"label",
+													"value"
+												],
+												"properties":{
+													"label":{
+														"type":"string"
+													},
+													"value":{
+														"type":"string"
+													}
+												}
+											}
+										},
+										"limitToOptions":{
+											"type":"boolean",
+											"default":false,
+											"title":"limit To Options",
+											"description":"Specifies that the users input is limited to the options list. When set to true without options, this should have no affect. When set to true with options, the user can only select the options from the list When set to false with options, the user can enter values other than those in the list."
+										},
+										"groupName":{
+											"type":"string",
+											"title":"Configuration Parameter Group Name",
+											"description":"A string used to group parameters together into logical blocks so that the UI can display them together."
+										},
+										"advanced":{
+											"type":"boolean",
+											"default":false,
+											"title":"An Advanced Configuration Parameter",
+											"description":"Specifies if this is an advanced parameter. An advanced parameter can be hidden in the UI to focus the user on important configuration."
+										}
+									}
+								}
+							},
+							"configuration":{
+								"type":"object",
+								"title":"Rule Configuration",
+								"description":"Used to define values of the configuration parameters of the Rule."
+							},
+							"triggers":{
+								"type":"array",
+								"minItems":1,
+								"title":"Trigger Modules",
+								"description":"Contains definitions of the Trigger Modules of the Rule.",
+								"items":{
+									"type":"object",
+									"title":"Trigger Module",
+									"description":"Defines the fact which triggers the Rule execution.",
+									"additionalProperties":false,
+									"required":[
+										"id",
+										"type"
+									],
+									"properties":{
+										"id":{
+											"type":"string",
+											"pattern":"[A-Za-z0-9_-]*",
+											"title":"Trigger ID",
+											"description":"Identifies uniquely the Module in scope of the Rule."
+										},
+										"label":{
+											"type":"string",
+											"title":"Trigger Label",
+											"description":"Short (one word) user friendly name of the Module."
+										},
+										"description":{
+											"type":"string",
+											"title":"Trigger Description",
+											"description":"A brief description of what the Trigger is and for what it is used."
+										},
+										"type":{
+											"type":"string",
+											"pattern":"[A-Za-z0-9_-]*",
+											"title":"Trigger Module Type UID",
+											"description": "Identifies the Module Type used for creation of the Trigger Composition."
+										},
+										"configuration":{
+											"type":"object",
+											"title":"Trigger Configuration",
+											"description":"Used to define values of the configuration parameters of the Trigger."
+										}
+									}
+								}
+							},
+							"conditions":{
+								"type":"array",
+								"minItems":1,
+								"title":"Condition Modules",
+								"description":"Contains definitions of Condition Modules of the Rule.",
+								"items":{
+									"type":"object",
+									"title":"Condition Module",
+									"description":"Defines the condition which permit to proceed with the Rule execution.",
+									"additionalProperties":false,
+									"required":[
+										"id",
+										"type"
+									],
+									"properties":{
+										"id":{
+											"type":"string",
+											"pattern":"[A-Za-z0-9_-]*",
+											"title":"Condition uid",
+											"description":"Identifies uniquely the Module in scope of the Rule."
+										},
+										"label":{
+											"type":"string",
+											"title":"Condition Label",
+											"description":"Short (one word) user friendly name of the Module."
+										},
+										"description":{
+											"type":"string",
+											"title":"Condition Description",
+											"description":"A brief description of what the Condition is and for what it is used."
+										},
+										"type":{
+											"type":"string",
+											"pattern":"[A-Za-z0-9_-]*",
+											"title":"Condition Module Type UID",
+											"description":"Identifies the Module Type used for creation of the Condition."
+										},
+										"configuration":{
+											"type":"object",
+											"title":"Condition Configuration",
+											"description":"Used to define values of the configuration parameters of the Condition."
+										},
+										"inputs":{
+											"type":"object",
+											"title":"Condition Inputs",
+											"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+										}
+									}
+								}
+							},
+							"actions":{
+								"type":"array",
+								"minItems":1,
+								"title":"Action Modules",
+								"description":"Contains definitions of Action Modules of the Rule.",
+								"items":{
+									"type":"object",
+									"title":"Action Module",
+									"description":"Defines an Action which has to be executed by the Rule.",
+									"additionalProperties":false,
+									"required":[
+										"id",
+										"type"
+									],
+									"properties":{
+										"id":{
+											"type":"string",
+											"pattern":"[A-Za-z0-9_-]*",
+											"title":"Action ID",
+											"description":"Identifies uniquely the Module in scope of the Rule."
+										},
+										"label":{
+											"type":"string",
+											"title":"Action Label",
+											"description":"Short (one word) user friendly name of the Module."
+										},
+										"description":{
+											"type":"string",
+											"title":"Action Description",
+											"description":"A brief description of what the Action is and for what it is used."
+										},
+										"type":{
+											"type":"string",
+											"pattern":"[A-Za-z0-9_-]*",
+											"title":"Action Module Type UID",
+											"description":"Identifies the Module Type used for creation of the Action."
+										},
+										"configuration":{
+											"type":"object",
+											"title":"Action Configuration",
+											"description":"Used to define values of the configuration parameters of the Action."
+										},
+										"inputs":{
+											"type":"object",
+											"title":"Action Inputs",
+											"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+										},
+										"outputs":{
+											"type":"object",
+											"title":"Action Outputs",
+											"description":"Contains pairs of Output Name and Output reference. The reference defines what part of a complex data has to be used as value of this output."
+										}
+									}
+								}
+							}
+						}
+					},
+					{
+						"type":"object",
+						"title":"Rule",
+						"description":"Rule Definition",
+						"additionalProperties":false,
+						"required":[
+							"template.uid"
+						],
+						"properties":{
+							"name":{
+								"type":"string",
+								"title":"Rule name",
+								"description":"Short (one word) user friendly name of the Rule."
+							},
+							"uid":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Rule uid",
+								"description":"An unique identifier of the Rule in scope of the Rule Engine."
+							},
+							"template.uid":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Rule Template UID",
+								"description":"Used for description of the Rule. It must be unique in scope of Template Registry."
+							},
+							"tags":{
+								"type":"array",
+								"title":"Rule Tags",
+								"description":"Non-hierarchical keywords or terms describing the Rule. They help to classify the rules and allow them to be found.",
+								"minItems":1,
+								"items":{
+									"type":"string",
+									"title":"Tag",
+									"description":"Keyword or term describing the Rule."
+								}
+							},
+							"description":{
+								"type":"string",
+								"title":"Rule Description",
+								"description":"A brief description of what the rule is and for what it is used."
+							},
+							"configuration":{
+								"type":"object",
+								"title":"Rule Configuration",
+								"description":"Used to define values of the configuration parameters of the Rule."
+							},
+							"visibility":{
+								"enum":[
+									"VISIBLE",
+									"HIDDEN",
+									"EXPERT"
+								],
+								"default":"VISIBLE",
+								"title":"Visibility",
+								"description":"Defines visibility of the Rule."
+							}
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/.vuepress/public/schemas/Templates_schema.json
+++ b/.vuepress/public/schemas/Templates_schema.json
@@ -1,0 +1,742 @@
+{
+	"$schema":"http://json-schema.org/draft-04/schema#",
+	"title":"Automation Template Definitions",
+	"description":"This schema is used for verification of JSON objects used for creation of Automation Object Templates.",
+	"oneOf":[
+	{
+		"type":"object",
+		"title":"Rule Template",
+		"description":"Rule Template Definition",
+		"additionalProperties":false,
+		"required":[
+			"uid",
+			"triggers",
+			"actions"
+		],
+		"properties":{
+			"label":{
+				"type":"string",
+				"title":"Rule Template Label",
+				"description":"Short (one word) user friendly name of the Rule Template."
+			},
+			"uid":{
+				"type":"string",
+				"pattern":"[A-Za-z0-9_-]*",
+				"title":"Rule Template UID",
+				"description":"An unique identifier of the Rule Template in scope of the Template Registry."
+			},
+			"tags":{
+				"type":"array",
+				"title":"Rule Template Tags",
+				"description":"Non-hierarchical keywords or terms describing the Rule. They help to classify the rule templates and allow them to be found.",
+				"minItems":1,
+				"items":{
+					"type":"string",
+					"title":"Tag",
+					"description":"Keyword or term describing the Rule Template."
+				}
+			},
+			"description":{
+				"type":"string",
+				"title":"Rule Template Description",
+				"description":"A brief description of what the rule is and for what it is used."
+			},
+			"visibility":{
+				"enum":[
+					"VISIBLE",
+					"HIDDEN",
+					"EXPERT"
+				],
+				"default":"VISIBLE",
+				"title":"Visibility",
+				"description":"Defines visibility of the Rule Template."
+			},
+			"configDescriptions":{
+				"type":"array",
+				"title":"Rule Template Configuration Descriptor",
+				"description":"Used to describe the configuration parameters of the Rule Template.",
+				"minItems":1,
+				"items":{
+					"type":"object",
+					"title":"Configuration Property Description",
+					"description":"Description of property for configuring the Rule Template.",
+					"additionalProperties":false,
+					"required":[
+						"name",
+						"type"
+					],
+					"properties":{
+						"name":{
+							"pattern":"[A-Za-z0-9_-]*",
+							"type":"string",
+							"title":"Configuration Parameter Name",
+							"description":"Identifies uniquely the configuration parameter in scope of the Rule Template."
+						},
+						"type":{
+							"enum":[
+								"TEXT",
+								"INTEGER",
+								"DECIMAL",
+								"BOOLEAN"
+							],
+							"title":"Configuration Parameter Type",
+							"description":"Property declaring the data type of the configuration parameter."
+						},
+						"label":{
+							"type":"string",
+							"title":"Configuration Parameter Label",
+							"description":"A human understandable label of the Configuration Parameter."
+						},
+						"description":{
+							"type":"string",
+							"title":"Configuration Parameter Description",
+							"description":"A human understandable description of the Configuration Parameter."
+						},
+						"required":{
+							"type":"boolean",
+							"default":false,
+							"title":"Required Configuration Parameter",
+							"description":"Specifies whether the value is required."
+						},
+						"min":{
+							"type":"number",
+							"title":"Configuration Parameter Minimum Allowed Value",
+							"description":"The minimal value for numeric types, or the minimal length of strings, or the minimal number of selected options."
+						},
+						"max":{
+							"type":"number",
+							"title":"Configuration Parameter Maximum Allowed Value",
+							"description":"The maximal value for numeric types, or the maximal length of strings, or the maximal number of selected options."
+						},
+						"step":{
+							"type":"number",
+							"title":"Configuration Parameter Step",
+							"description":"The value granularity for a numeric value"
+						},
+						"pattern":{
+							"type":"string",
+							"title":"Configuration Parameter Pattern",
+							"description":"The regular expression for a text type."
+						},
+						"readOnly":{
+							"type":"boolean",
+							"default":false,
+							"title":"Readable Configuration Parameter",
+							"description":"Specifies whether the value is read-only."
+						},
+						"multiple":{
+							"type":"boolean",
+							"default":false,
+							"title":"Multiple Configuration Parameter",
+							"description":"Specifies whether multiple selections of options are allowed."
+						},
+						"multipleLimit":{
+							"type":"number",
+							"title":"Multiple Configuration Parameter Limit",
+							"description":"Specifies the maximum number of options that can be selected when multiple is true."
+						},
+						"context":{
+							"type":"string",
+							"title":"Configuration Parameter Context",
+							"description":"Serves to determine how to treat the value of the Configuration Parameter."
+						},
+						"default":{
+							"type":"string",
+							"title":"Configuration Parameter Default Value",
+							"description":"Declaring a default value for the Configuration Parameter if missing."
+						},
+						"unit":{
+							"type":"string",
+							"title":"Configuration Parameter Unit",
+							"description":"Specifies the unit of measurements for the configuration parameter."
+						},
+						"unitLabel":{
+							"type":"string",
+							"title":"Configuration Parameter Unit Label",
+							"description":"Specifies the unit label for the configuration parameter. This attribute can also be used to provide natural language units as iterations, runs, etc."
+						},
+						"filterCriteria":{
+							"type":"array",
+							"title":"Configuration Parameter Filter",
+							"description":"Criteria for dynamic selection of values.",
+							"items":{
+								"type":"object",
+								"additionalProperties":false,
+								"required":[
+									"name",
+									"value"
+								],
+								"properties":{
+									"name":{
+										"type":"string"
+									},
+									"value":{
+										"type":"string"
+									}
+								}
+							}
+						},
+						"options":{
+							"type":"array",
+							"title":"Configuration Parameter Options",
+							"description":"List of definitions of the parameter for static selection.",
+							"items":{
+								"type":"object",
+								"additionalProperties":false,
+								"required":[
+									"label",
+									"value"
+								],
+								"properties":{
+									"label":{
+										"type":"string"
+									},
+									"value":{
+										"type":"string"
+									}
+								}
+							}
+						},
+						"limitToOptions":{
+							"type":"boolean",
+							"default":false,
+							"title":"limit To Options",
+							"description":"Specifies that the users input is limited to the options list. When set to true without options, this should have no affect. When set to true with options, the user can only select the options from the list When set to false with options, the user can enter values other than those in the list."
+						},
+						"groupName":{
+							"type":"string",
+							"title":"Configuration Parameter Group Name",
+							"description":"A string used to group parameters together into logical blocks so that the UI can display them together."
+						},
+						"advanced":{
+							"type":"boolean",
+							"default":false,
+							"title":"An Advanced Configuration Parameter",
+							"description":"Specifies if this is an advanced parameter. An advanced parameter can be hidden in the UI to focus the user on important configuration."
+						}
+					}
+				}
+			},
+			"triggers":{
+				"type":"array",
+				"minItems":1,
+				"title":"Trigger Modules",
+				"description":"Contains definitions of the Trigger Modules of the Rule Template.",
+				"items":{
+					"type":"object",
+					"title":"Trigger Module",
+					"description":"Defines the fact which triggers the Rule execution.",
+					"additionalProperties":false,
+					"required":[
+						"id",
+						"type"
+					],
+					"properties":{
+						"id":{
+							"type":"string",
+							"pattern":"[A-Za-z0-9_-]*",
+							"title":"Trigger ID",
+							"description":"Identifies uniquely the Module in scope of the Rule Template."
+						},
+						"label":{
+							"type":"string",
+							"title":"Trigger Label",
+							"description":"Short (one word) user friendly name of the Module."
+						},
+						"description":{
+							"type":"string",
+							"title":"Trigger Description",
+							"description":"A brief description of what the Trigger is and for what it is used."
+						},
+						"type":{
+							"type":"string",
+							"pattern":"[A-Za-z0-9_-]*",
+							"title":"Trigger Module Type UID",
+							"description":"Identifies the Module Type used for creation of the Trigger Module."
+						},
+						"configuration":{
+							"type":"object",
+							"title":"Trigger Configuration",
+							"description":"Used to define values of the configuration parameters of the Trigger."
+						}
+					}
+				}
+			},
+			"conditions":{
+				"type":"array",
+				"minItems":1,
+				"title":"Condition Modules",
+				"description":"Contains definitions of Condition Modules of the Rule Template.",
+				"items":{
+					"type":"object",
+					"title":"Condition Module",
+					"description":"Defines the condition which permit to proceed with the Rule execution.",
+					"additionalProperties":false,
+					"required":[
+						"id",
+						"type"
+					],
+					"properties":{
+						"id":{
+							"type":"string",
+							"pattern":"[A-Za-z0-9_-]*",
+							"title":"Condition uid",
+							"description":"Identifies uniquely the Module in scope of the Rule Template."
+						},
+						"label":{
+							"type":"string",
+							"title":"Condition Label",
+							"description":"Short (one word) user friendly name of the Module."
+						},
+						"description":{
+							"type":"string",
+							"title":"Condition Description",
+							"description":"A brief description of what the Condition is and for what it is used."
+						},
+						"type":{
+							"type":"string",
+							"pattern":"[A-Za-z0-9_-]*",
+							"title":"Condition Module Type UID",
+							"description":"Identifies the Module Type used for creation of the Condition."
+						},
+						"configuration":{
+							"type":"object",
+							"title":"Condition Configuration",
+							"description":"Used to define values of the configuration parameters of the Condition."
+						},
+						"inputs":{
+							"type":"object",
+							"title":"Condition Input",
+							"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+						}
+					}
+				}
+			},
+			"actions":{
+				"type":"array",
+				"minItems":1,
+				"title":"Action Modules",
+				"description":"Contains definitions of Action Modules of the Rule Template.",
+				"items":{
+					"type":"object",
+					"title":"Action Module",
+					"description":"Defines an Action which has to be executed by the Rule.",
+					"additionalProperties":false,
+					"required":[
+						"id",
+						"type"
+					],
+					"properties":{
+						"id":{
+							"type":"string",
+							"pattern":"[A-Za-z0-9_-]*",
+							"title":"Action ID",
+							"description":"Identifies uniquely the Module in scope of the Rule Template."
+						},
+						"label":{
+							"type":"string",
+							"title":"Action Label",
+							"description":"Short (one word) user friendly name of the Module."
+						},
+						"description":{
+							"type":"string",
+							"title":"Action Description",
+							"description":"A brief description of what the Action is and for what it is used."
+						},
+						"type":{
+							"type":"string",
+							"pattern":"[A-Za-z0-9_-]*",
+							"title":"Action Module Type UID",
+							"description":"Identifies the Module Type used for creation of the Action."
+						},
+						"configuration":{
+							"type":"object",
+							"title":"Action Configuration",
+							"description":"Used to define values of the configuration parameters of the Action."
+						},
+						"inputs":{
+							"type":"object",
+							"title":"Action Input",
+							"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+						},
+						"outputs":{
+							"type":"object",
+							"title":"Action Output",
+							"description":"Contains pairs of Output Name and Output reference. The reference defines what part of a complex data has to be used as value of this output."
+						}
+					}
+				}
+			}
+		}
+	},
+	{
+		"type":"array",
+		"minItems":1,
+		"items":{
+			"type":"object",
+			"title":"Rule Template",
+			"description":"Rule Template Definition",
+			"additionalProperties":false,
+			"required":[
+				"uid",
+				"triggers",
+				"actions"
+			],
+			"properties":{
+				"label":{
+					"type":"string",
+					"title":"Rule Template Label",
+					"description":"Short (one word) user friendly name of the Rule Template."
+				},
+				"uid":{
+					"type":"string",
+					"pattern":"[A-Za-z0-9_-]*",
+					"title":"Rule Template UID",
+					"description":"An unique identifier of the Rule Template in scope of the Template Registry."
+				},
+				"tags":{
+					"type":"array",
+					"title":"Rule Template Tags",
+					"description":"Non-hierarchical keywords or terms describing the Rule. They help to classify the rule templates and allow them to be found.",
+					"minItems":1,
+					"items":{
+						"type":"string",
+						"title":"Tag",
+						"description":"Keyword or term describing the Rule Template."
+					}
+				},
+				"description":{
+					"type":"string",
+					"title":"Rule Template Description",
+					"description":"A brief description of what the rule is and for what it is used."
+				},
+				"visibility":{
+					"enum":[
+						"VISIBLE",
+						"HIDDEN",
+						"EXPERT"
+					],
+					"default":"VISIBLE",
+					"title":"Visibility",
+					"description":"Defines visibility of the Rule Template."
+				},
+				"configDescriptions":{
+					"type":"array",
+					"title":"Rule Template Configuration Descriptor",
+					"description":"Used to describe the configuration parameters of the Rule Template.",
+					"minItems":1,
+					"items":{
+						"type":"object",
+						"title":"Configuration Property Description",
+						"description":"Description of property for configuring the Rule Template.",
+						"additionalProperties":false,
+						"required":[
+							"name",
+							"type"
+						],
+						"properties":{
+							"name":{
+								"pattern":"[A-Za-z0-9_-]*",
+								"type":"string",
+								"title":"Configuration Parameter Name",
+								"description":"Identifies uniquely the configuration parameter in scope of the Rule Template."
+							},
+							"type":{
+								"enum":[
+									"TEXT",
+									"INTEGER",
+									"DECIMAL",
+									"BOOLEAN"
+								],
+								"title":"Configuration Parameter Type",
+								"description":"Property declaring the data type of the configuration parameter."
+							},
+							"label":{
+								"type":"string",
+								"title":"Configuration Parameter Label",
+								"description":"A human understandable label of the Configuration Parameter."
+							},
+							"description":{
+								"type":"string",
+								"title":"Configuration Parameter Description",
+								"description":"A human understandable description of the Configuration Parameter."
+							},
+							"required":{
+								"type":"boolean",
+								"default":false,
+								"title":"Required Configuration Parameter",
+								"description":"Specifies whether the value is required."
+							},
+							"min":{
+								"type":"number",
+								"title":"Configuration Parameter Minimum Allowed Value",
+								"description":"The minimal value for numeric types, or the minimal length of strings, or the minimal number of selected options."
+							},
+							"max":{
+								"type":"number",
+								"title":"Configuration Parameter Maximum Allowed Value",
+								"description":"The maximal value for numeric types, or the maximal length of strings, or the maximal number of selected options."
+							},
+							"step":{
+								"type":"number",
+								"title":"Configuration Parameter Step",
+								"description":"The value granularity for a numeric value"
+							},
+							"pattern":{
+								"type":"string",
+								"description":"The regular expression for a text type."
+							},
+							"readOnly":{
+								"type":"boolean",
+								"default":false,
+								"title":"Readable Configuration Parameter",
+								"description":"Specifies whether the value is read-only."
+							},
+							"multiple":{
+								"type":"boolean",
+								"default":false,
+								"title":"Multiple Configuration Parameter",
+								"description":"Specifies whether multiple selections of options are allowed."
+							},
+							"multipleLimit":{
+								"type":"number",
+								"title":"Multiple Configuration Parameter Limit",
+								"description":"Specifies the maximum number of options that can be selected when multiple is true."
+							},
+							"context":{
+								"type":"string",
+								"title":"Configuration Parameter Context",
+								"description":"Serves to determine how to treat the value of the Configuration Parameter."
+							},
+							"default":{
+								"type":"string",
+								"title":"Configuration Parameter Default Value",
+								"description":"Declaring a default value for the Configuration Parameter if missing."
+							},
+							"unit":{
+								"type":"string",
+								"title":"Configuration Parameter Unit",
+								"description":"Specifies the unit of measurements for the configuration parameter."
+							},
+							"unitLabel":{
+								"type":"string",
+								"title":"Configuration Parameter Unit Label",
+								"description":"Specifies the unit label for the configuration parameter. This attribute can also be used to provide natural language units as iterations, runs, etc."
+							},
+							"filterCriteria":{
+								"type":"array",
+								"title":"Configuration Parameter Filter",
+								"description":"Criteria for dynamic selection of values.",
+								"items":{
+									"type":"object",
+									"additionalProperties":false,
+									"required":[
+										"name",
+										"value"
+									],
+									"properties":{
+										"name":{
+											"type":"string"
+										},
+										"value":{
+											"type":"string"
+										}
+									}
+								}
+							},
+							"options":{
+								"type":"array",
+								"title":"Configuration Parameter Options",
+								"description":"List of definitions of the parameter for static selection.",
+								"items":{
+									"type":"object",
+									"additionalProperties":false,
+									"required":[
+										"label",
+										"value"
+									],
+									"properties":{
+										"label":{
+											"type":"string"
+										},
+										"value":{
+											"type":"string"
+										}
+									}
+								}
+							},
+							"limitToOptions":{
+								"type":"boolean",
+								"default":false,
+								"title":"limit To Options",
+								"description":"Specifies that the users input is limited to the options list. When set to true without options, this should have no affect. When set to true with options, the user can only select the options from the list When set to false with options, the user can enter values other than those in the list."
+							},
+							"groupName":{
+								"type":"string",
+								"title":"Configuration Parameter Group Name",
+								"description":"A string used to group parameters together into logical blocks so that the UI can display them together."
+							},
+							"advanced":{
+								"type":"boolean",
+								"default":false,
+								"title":"An Advanced Configuration Parameter",
+								"description":"Specifies if this is an advanced parameter. An advanced parameter can be hidden in the UI to focus the user on important configuration."
+							}
+						}
+					}
+				},
+				"triggers":{
+					"type":"array",
+					"minItems":1,
+					"title":"Trigger Modules",
+					"description":"Contains definitions of the Trigger Modules of the Rule Template.",
+					"items":{
+						"type":"object",
+						"title":"Trigger Module",
+						"description":"Defines the fact which triggers the Rule execution.",
+						"additionalProperties":false,
+						"required":[
+							"id",
+							"type"
+						],
+						"properties":{
+							"id":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Trigger ID",
+								"description":"Identifies uniquely the Module in scope of the Rule Template."
+							},
+							"label":{
+								"type":"string",
+								"title":"Trigger Label",
+								"description":"Short (one word) user friendly name of the Module."
+							},
+							"description":{
+								"type":"string",
+								"title":"Trigger Description",
+								"description":"A brief description of what the Trigger is and for what it is used."
+							},
+							"type":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Trigger Module Type UID",
+								"description":"Identifies the Module Type used for creation of the Trigger Module."
+							},
+							"configuration":{
+								"type":"object",
+								"title":"Trigger Configuration",
+								"description":"Used to define values of the configuration parameters of the Trigger."
+							}
+						}
+					}
+				},
+				"conditions":{
+					"type":"array",
+					"minItems":1,
+					"title":"Condition Modules",
+					"description":"Contains definitions of Condition Modules of the Rule Template.",
+					"items":{
+						"type":"object",
+						"title":"Condition Module",
+						"description":"Defines the condition which permit to proceed with the Rule execution.",
+						"additionalProperties":false,
+						"required":[
+							"id",
+							"type"
+						],
+						"properties":{
+							"id":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Condition uid",
+								"description":"Identifies uniquely the Module in scope of the Rule Template."
+							},
+							"label":{
+								"type":"string",
+								"title":"Condition Label",
+								"description": "Short (one word) user friendly name of the Module."
+							},
+							"description":{
+								"type":"string",
+								"title":"Condition Description",
+								"description":"A brief description of what the Condition is and for what it is used."
+							},
+							"type":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Condition Module Type UID",
+								"description":"Identifies the Module Type used for creation of the Condition."
+							},
+							"configuration":{
+								"type":"object",
+								"title":"Condition Configuration",
+								"description":"Used to define values of the configuration parameters of the Condition."
+							},
+							"inputs":{
+								"type":"object",
+								"title":"Condition Inputs",
+								"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+							}
+						}
+					}
+				},
+				"actions":{
+					"type":"array",
+					"minItems":1,
+					"title":"Action Modules",
+					"description":"Contains definitions of Action Modules of the Rule Template.",
+					"items":{
+						"type":"object",
+						"title":"Action Module",
+						"description":"Defines an Action which has to be executed by the Rule.",
+						"additionalProperties":false,
+						"required":[
+							"id",
+							"type"
+						],
+						"properties":{
+							"id":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Action ID",
+								"description":"Identifies uniquely the Module in scope of the Rule Template."
+							},
+							"label":{
+								"type":"string",
+								"title":"Action Label",
+								"description":"Short (one word) user friendly name of the Module."
+							},
+							"description":{
+								"type":"string",
+								"title":"Action Description",
+								"description":"A brief description of what the Action is and for what it is used."
+							},
+							"type":{
+								"type":"string",
+								"pattern":"[A-Za-z0-9_-]*",
+								"title":"Action Module Type UID",
+								"description":"Identifies the Module Type used for creation of the Action."
+							},
+							"configuration":{
+								"type":"object",
+								"title":"Action Configuration",
+								"description":"Used to define values of the configuration parameters of the Action."
+							},
+							"inputs":{
+								"type":"object",
+								"title":"Action Inputs",
+								"description":"Contains pairs of Input Name and Output reference in format - Module ID : Output Name."
+							},
+							"outputs":{
+								"type":"object",
+								"title":"Action Outputs",
+								"description":"Contains pairs of Output Name and Output reference. The reference defines what part of a complex data has to be used as value of this output."
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	]
+}


### PR DESCRIPTION
As discussed at https://github.com/openhab/openhab-docs/issues/1081, the JSON schemas for Rules are missing on the openHAB website. I've copied them over from the ESH website.

Signed-off-by: Rich Koshak <rlkoshak@gmail.com>