### PR TITLE
Add headers for more aggressive caching by Cloudflare

### DIFF
--- a/.vuepress/_headers
+++ b/.vuepress/_headers
@@ -8,7 +8,9 @@
   Cache-Control: public, s-max-age=604800
 /os/*
   Cache-Control: public, s-max-age=604800
-*.png
+/:image.png
+  Cache-Control: public, s-max-age=604800
+/:image.jpg
   Cache-Control: public, s-max-age=604800
 /v2*
   Cache-Control: public, s-max-age=604800

--- a/.vuepress/_headers
+++ b/.vuepress/_headers
@@ -1,2 +1,14 @@
 /fonts/*
   Cache-Control: public, max-age=31536000, stale-while-revalidate=604800
+/logos/*
+  Cache-Control: public, s-max-age=604800
+/assets/*
+  Cache-Control: public, s-max-age=604800
+/uploads/*
+  Cache-Control: public, s-max-age=604800
+/os/*
+  Cache-Control: public, s-max-age=604800
+*.png
+  Cache-Control: public, s-max-age=604800
+/v2*
+  Cache-Control: public, s-max-age=604800


### PR DESCRIPTION
Resources like images, logos, uploads, and site snapshots for earlier versions shouldn't need revalidation and may be cached by Cloudflare more aggressively.

Files in `/assets` include a cache-busting hash (https://github.com/openhab/openhab.github.io/tree/master/assets) so it's safe to aggressively cache them too.

Inspired by https://codewithhugo.com/enable-cdn-netlify/.

Signed-off-by: Yannick Schaus <github@schaus.net>