### PR TITLE
Adapted scripts and config to OH3 branching.

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -60,7 +60,7 @@ module.exports = {
         if ((str.match(/\brule\b/) && str.match(/\bwhen\b/) && str.match(/\bthen\b/) && str.match(/\bend\b/)) ||
           str.match(/received update/) || str.match(/changed.*(?:from|to)/) || str.match(/Channel.*triggered/) ||
           str.match(/\bval\b/) || str.match(/\bvar\b/) /* <-- dangerous! */) {
-          
+
           lang = 'rules'
         }
         if (lang === 'shell' || lang === 'sh' || lang === 'shell_session') lang = 'bash'
@@ -266,11 +266,9 @@ module.exports = {
             'configuration/editors',
             'configuration/homebuilder',
             ['configuration/paperui', 'Paper UI'],
-            ['configuration/ui/habmin/', 'HABmin'],
             ['configuration/ui/habot/', 'HABot'],
             'configuration/habpanel',
             ['configuration/ui/basic/', 'Basic UI'],
-            ['configuration/ui/classic/', 'Classic UI'],
             'configuration/rules-ng',
             'configuration/eclipseiotmarket',
             ['configuration/restdocs', 'REST API'],

--- a/prepare-docs.rb
+++ b/prepare-docs.rb
@@ -103,10 +103,7 @@ def process_file(indir, file, outdir, source)
                             addon_type = outdir_parts[1]
                             addon = file.split('/')[0]
                             source = ""
-                            if addon == "habmin" then
-                                puts "    (add-on is habmin)"
-                                source = "https://github.com/openhab/org.openhab.ui.habmin/blob/master/README.md"
-                            elsif addon == "habpanel" then
+                            if addon == "habpanel" then
                                 puts "    (add-on is habpanel)"
                                 source = "https://github.com/openhab/org.openhab.ui.habpanel/blob/master/README.md"
                             elsif addon == "zigbee" then
@@ -169,8 +166,6 @@ def process_file(indir, file, outdir, source)
             if outdir == 'docs/configuration' && file =~ /packages/ then
                 line = line.gsub('(../addons/uis/paper/readme.html)', '(paperui.html)')
                 line = line.gsub('(../addons/uis/basic/readme.html)', '(ui/basic/)')
-                line = line.gsub('(../addons/uis/classic/readme.html)', '(ui/classic/)')
-                line = line.gsub('(../addons/uis/habmin/readme.html)', '(ui/habmin/)')
                 line = line.gsub('(../addons/uis/habpanel/readme.html)', '(habpanel.html)')
             end
 
@@ -228,7 +223,6 @@ def process_file(indir, file, outdir, source)
             # Misc replaces (relative links, remove placeholder interpreted as custom tags)
             line = line.gsub('http://docs.openhab.org/addons/uis/paper/readme.html', '/docs/configuration/paperui.html')
             line = line.gsub('http://docs.openhab.org/addons/uis/habpanel/readme.html', '/docs/configuration/habpanel.html')
-            line = line.gsub('http://docs.openhab.org/addons/uis/habmin/readme.html', '/docs/configuration/habmin.html')
             line = line.gsub('http://docs.openhab.org/addons/uis/basic/readme.html', '/docs/configuration/ui/basic/')
             line = line.gsub(/http:\/\/docs\.openhab\.org\/addons\/(.*)\/(.*)\/readme\.html/, '/addons/\1/\2/')
             line = line.gsub('http://docs.openhab.org/', '/docs/')


### PR DESCRIPTION
CC: @kaikreuzer @ghys 

Since master branches switched to OH3 and habmin/classicui were removed in openhab-webui repo,
the website build is broken. (Also the previes, for the same reason.)

I have removed the legacy uis from docs generation.
Also i removed the corresponding sidebar entries.

Will do the same for the related scripts and configs in the docs repo.
This includes vuepress related scripts and also our gathering bash script, for external contents.
(PR will follow over there.)

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>