### PR TITLE
Note added to IFTTT doc that item expose is disabled on myopenHAB.com

### DIFF
--- a/docs/ecosystem/ifttt/readme.md
+++ b/docs/ecosystem/ifttt/readme.md
@@ -8,6 +8,11 @@ meta:
   - name: og:description
     content: "openHAB users can take advantage of IFTTT to realize even more use cases in their smart home!"
 ---
+::: tip Note
+ The function to expose new items to [If This Then That (IFTTT)](https://ifttt.com) via [myopenHAB.org](https://myopenHAB.org) is currently disabled, so if you want to integrate IFTTT with openHAB you will have to set up your own private instance of [openhab-cloud](https://github.com/openhab/openhab-cloud) as well as setting up your own service on IFTTT. Please keep in mind that this will also require additional effort if you want to use other add-ons that depend on myopenHAB.org, like the Amazon Alexa skill. _Some add-ons, like the iOS app can be configured to connect to your private instance, others, like the Amazon Alexa skill, can not._
+
+ This guide describes the standard setup for if and when the function to expose items on myopenHAB.org is re-enabled or if you had items exposed already before July 2019. If you want  to go down the route of setting up your own openhab-cloud there are several helpful posts in the [openHAB Community]( https://community.openhab.org). 
+:::
 
 # IFTTT Integration for openHAB
 

--- a/docs/ecosystem/ifttt/readme.md
+++ b/docs/ecosystem/ifttt/readme.md
@@ -8,13 +8,14 @@ meta:
   - name: og:description
     content: "openHAB users can take advantage of IFTTT to realize even more use cases in their smart home!"
 ---
+
+# IFTTT Integration for openHAB
+
 ::: tip Note
  The function to expose new items to [If This Then That (IFTTT)](https://ifttt.com) via [myopenHAB.org](https://myopenHAB.org) is currently disabled, so if you want to integrate IFTTT with openHAB you will have to set up your own private instance of [openhab-cloud](https://github.com/openhab/openhab-cloud) as well as setting up your own service on IFTTT. Please keep in mind that this will also require additional effort if you want to use other add-ons that depend on myopenHAB.org, like the Amazon Alexa skill. _Some add-ons, like the iOS app can be configured to connect to your private instance, others, like the Amazon Alexa skill, can not._
 
  This guide describes the standard setup for if and when the function to expose items on myopenHAB.org is re-enabled or if you had items exposed already before July 2019. If you want  to go down the route of setting up your own openhab-cloud there are several helpful posts in the [openHAB Community]( https://community.openhab.org). 
 :::
-
-# IFTTT Integration for openHAB
 
 [If This Then That (IFTTT)](https://ifttt.com) is a very popular web-based service that allows users to create "applets", which can combine different web services into powerful automation rules. 
 With its [hundreds of services](https://ifttt.com/services), there are limitless new creative options: Be notified through text-to-speech if you are receive a DM on twitter, be warned through your lights if your favorite stock price falls below a certain threshold or put your house in away-mode when you turn on the ignition of your car - you can get further inspiration by browsing through existing applets.


### PR DESCRIPTION
Since there are regular posts in the community from people who have started to set up IFTTT and spend hours trying to get their items to show up on myopenhab.com, it would be helpful if this is mentioned in the doc.