### PR TITLE
Update snapshot download URL

### DIFF
--- a/.vuepress/components/InstallInstructions.vue
+++ b/.vuepress/components/InstallInstructions.vue
@@ -183,7 +183,7 @@ usermod -a -G openhab myownuser
         <li>Install a recent Java 8 platform (we recommend <a target="_blank" href="https://www.azul.com/products/zulu/">Zulu</a>)</li>
         <li>Download and extract the distribution from <a href="https://ci.openhab.org/">https://ci.openhab.org/</a>:</li>
         <div class="download-button-container">
-          <a target="_blank" class="download-button big" :href="`https://ci.openhab.org/job/openHAB-Distribution/`">Latest openHAB {{$page.frontmatter.currentSnapshotVersion}} Build</a>
+          <a target="_blank" class="download-button big" :href="`https://ci.openhab.org/view/Integration%20Builds%20(2.5.x)/job/openHAB-Distribution/`">Latest openHAB {{$page.frontmatter.currentSnapshotVersion}} Build</a>
         </div>
       </ol>
     </div>

--- a/download/README.md
+++ b/download/README.md
@@ -4,7 +4,7 @@ layout: AboutPage
 title: Download openHAB
 currentVersion: 2.5.1
 currentMilestoneVersion: 2.5.1
-currentSnapshotVersion: 3.0.0-SNAPSHOT
+currentSnapshotVersion: 2.5.2-SNAPSHOT
 meta:
   - name: og:title
     content: Download openHAB


### PR DESCRIPTION
Change the CI URL to the latest 2.5.x build of the distribution.
The OH 3.x snapshot download link will appear on the "next" website
when it's ready.

Signed-off-by: Yannick Schaus <github@schaus.net>