### PR TITLE
[next] Re-activate prefetching

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -23,7 +23,6 @@ module.exports = {
   host: 'localhost',
   base,
   ga: 'UA-47717934-1',
-  shouldPrefetch: () => false,
   plugins: ['tabs', 'container'],
   head: [
     ['link', { rel: 'stylesheet', href: `/fonts/fonts.css` }],


### PR DESCRIPTION
Bandwidth quotas being pretty much not an issue anymore, let's try re-enabling prefetching pages in advance to speed up page transitions.

Signed-off-by: Yannick Schaus <github@schaus.net>