### PR TITLE
Update documentation branches

### DIFF
--- a/prepare-docs.rb
+++ b/prepare-docs.rb
@@ -8,9 +8,9 @@ require "rexml/document"
 # require "nokogiri"
 
 $docs_repo = "https://github.com/openhab/openhab-docs"
-$docs_repo_root = $docs_repo + "/blob/2.5.x"
+$docs_repo_root = $docs_repo + "/blob/main"
 $docs_repo_branch = "final-2.5.x"
-$addons_repo_branch = "2.5.x"
+$addons_repo_branch = "main"
 $version = nil
 
 $ignore_addons = ['transport.modbus', 'transport.feed', 'javasound', 'webaudio', 'oh2']


### PR DESCRIPTION
This will adjust the branches that "edit" links lead to (`main`), but for now, not where the docs
are actually taken from ($docs_repo_branch = "final-2.5.x"`), because the current website should
still be displaying docs for openHAB 2, the next.openhab.org website has the current docs
though.

Signed-off-by: Yannick Schaus <github@schaus.net>