### PR TITLE
Remove assets caching

### DIFF
--- a/.vuepress/_headers
+++ b/.vuepress/_headers
@@ -2,8 +2,6 @@
   Cache-Control: public, max-age=31536000, immutable
 /logos/*
   Cache-Control: public, max-age=604800, s-maxage=604800
-/assets/*
-  Cache-Control: public, max-age=604800, s-maxage=604800
 /uploads/*
   Cache-Control: public, max-age=604800, s-maxage=604800
 /os/*


### PR DESCRIPTION
Following information from https://community.cloudflare.com/t/how-to-avoid-caching-404/196262
and https://support.cloudflare.com/hc/en-us/articles/200172516-Understanding-Cloudflare-s-CDN#h_51422705-42d0-450d-8eb1-5321dcadb5bc

CloudFlare will cache 404s for 3 minutes **if** there is no cache-control header directives.
Since we get many problems with assets/*.js cached as 404 when they in fact do exist and must be loaded for the website to function, don't provide any directives for the cache-control of those files, and let CloudFlare apply its defaults for them.

This should have a negligible impact on Netlify bandwidth consumption, but better to keep an eye on it anyway.

Signed-off-by: Yannick Schaus <github@schaus.net>