### PR TITLE
Added redirect for releases

### DIFF
--- a/.vuepress/_redirects
+++ b/.vuepress/_redirects
@@ -16,7 +16,8 @@
 
 # Redirect download locations
 
-/download/repo/*          https://openhab.jfrog.io/artifactory/libs-milestone-local/:splat 302
+/download/milestones/*        https://openhab.jfrog.io/artifactory/libs-milestone-local/:splat 302
+/download/releases/*          https://openhab.jfrog.io/artifactory/libs-release-local/:splat 302
 
 # Redirect v1 addon docs to the v2 subdomain
 


### PR DESCRIPTION
Introducing separate redirects for milestones and releases, so that we are flexible with future routing of requests.

Related to openhab/openhab-distro#1256

Signed-off-by: Kai Kreuzer <kai@openhab.org>