### PR TITLE
Rework version switcher

### DIFF
--- a/.vuepress/components/DocPreviousVersions.vue
+++ b/.vuepress/components/DocPreviousVersions.vue
@@ -1,105 +1,82 @@
 <template>
   <div class="page-versions">
-    <div class="dropdown-wrapper" :class="{ open }">
-      <a class="dropdown-title" @click="toggle">
-        <span class="title">Version: {{currentVersion}}</span>
-        <span class="arrow" :class="open ? 'down' : 'right'"></span></span>
-      </a>
-      <ul class="nav-dropdown" v-show="open">
-        <li v-for="version in versions" class="dropdown-item">
-          <a class="current" v-if="version.number === currentVersion">{{version.number}}</a>
-          <a v-else :href="version.url">{{version.number}}</a>
-        </li>
-      </ul>
+    <ul class="version-switcher">
+      <li><a :href="siteUrl('Stable')" class="version-button" :class="{ current: currentVersion === 'Stable' }">Stable</a></li>
+      <li><a :href="siteUrl('Latest')" class="version-button" :class="{ current: currentVersion === 'Latest' }">Latest</a></li>
+    </ul>
+    <div class="other-versions">
+      <a :href="siteUrl('v2')" @click="switchVersion('2.x')">v2.5</a>
     </div>
   </div>
 </template>
 
 <style lang="stylus">
-.content:not(.custom)>h1:first-child
-  margin-right 140px
 .page-versions
-  white-space nowrap
-  font-size 9pt
-  margin 5px
-  padding 3px
-  height 14px
-  user-select none
-  .dropdown-wrapper
-    padding 2px
-    position absolute
-    left 1rem
-  .dropdown-title
-    border 1px solid #eee
-    border-radius 2px
-    padding 5px
-    color black
+  margin-top 1rem
+.version-switcher
+  list-style-type none
+  padding .5rem
+  display flex
+  flex-direction row
+  justify-content center
+  .version-button
+    width 6.5rem
+    border 1px solid #2c3e50
+    color #2c3e50
+    background transparent
+    font-family 'Open Sans', sans-serif
+    font-weight 300
+    font-size 14px
+    padding 4px
     cursor pointer
-    &:hover
-      text-decoration none !important
-      border 1px solid #ccc
-  .nav-dropdown
-    box-sizing border-box
-    max-height calc(100vh - 2.7rem)
-    overflow-y auto
-    top 100%
-    right 0
-    background-color #fff
-    padding 10px 0
-    border 1px solid #ddd
-    border-bottom-color #ccc
-    text-align left
-    border-radius 0.25rem
-    white-space nowrap
-    margin 0;
-    position relative
-    top 0
-    .current
-      color black
-      font-weight bold !important
-      &:hover
-        text-decoration none
-        color black
+    text-align center
+    &.current
+      background #2c3e50
+      color #fff
+      cursor not-allowed
+.other-versions
+  text-align center
+  font-size 12px
+  margin-top 0.2rem
+  a
+    color #2c3e50 !important
+
+@media (prefers-color-scheme: dark)
+  .version-switcher
+    .version-button
+      border 1px solid #a6a6a6 !important
+      color #a6a6a6 !important
+      &.current
+        background #a6a6a6 !important
+        color #fff !important
+  .other-versions
+    a
+      color #a6a6a6 !important
 </style>
 
 <script>
 export default {
   data () {
     return {
-      versionNumbers: ['latest', '2.5', '2.4', '2.3', '2.2'], //, '2.1'],
-      currentVersion: 'latest',
-      open: false
+      currentVersion: null
     }
   },
   methods: {
-    toggle () {
-      this.open = !this.open
+    siteUrl (version) {
+      if (version === this.currentVersion) return null
+      let url = (this.$page.path.indexOf('/addons') === 0) ? this.$page.path.substring(1) : this.$page.path.split('/')[1]
+      if (version === 'Stable') {
+        url = 'https://www.openhab.org/' + url
+      } else if (version === 'Latest') {
+        url = 'https://next.openhab.org/' + url
+      } else if (version === 'v2') {
+        url = 'https://v2.openhab.org/' + url
+      }
+      return url
     }
   },
-  created () {
-    if (this.$site.base && this.$site.base.indexOf('v') > 0) {
-      this.currentVersion = this.$site.base.replace('v', '').replace(/\//g, '')
-      this.versionNumbers = ['latest', this.currentVersion] // to avoid having to regenerate previous sites
-    }
-  },
-  computed: {
-    versions () {
-      return this.versionNumbers.map(version => {
-        let url = (this.$page.path.indexOf('/addons') === 0) ? this.$page.path.substring(1) : this.$page.path.split('/')[1]
-        if (version === 'latest') {
-          url = 'https://www.openhab.org/' + url
-        } else if (version[0] === '2') {
-          url = `https://v2.openhab.org${version === 'snapshot' ? '' : '/v' + version}/${url}`
-        } else {
-          url = `https://v${version.replace('.', '').replace('0', '')}.openhab.org/${url}`
-        }
-
-        return {
-          number: version,
-          url: url
-        }
-      })
-    }
+  mounted () {
+    this.currentVersion = this.$site.themeConfig.docsVersion
   }
 }
 </script>

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -16,6 +16,12 @@ const DocsSidebarNavigation = require('./openhab-docs/.vuepress/docs-sidebar.js'
 
 const noAddons = process.env.OH_NOADDONS
 
+if (!process.env.OH_DOCS_VERSION) {
+  throw new Error('Please set the OH_DOCS_VERSION environment variable to the name of the branch of the openhab-docs repo that has been prepared')
+}
+
+const docsVersion = process.env.OH_DOCS_VERSION.replace('final-stable', 'Stable').replace('final', 'Latest')
+
 module.exports = {
   title: 'openHAB',
   description: 'openHAB - a vendor and technology agnostic open source automation software for your home',
@@ -112,6 +118,7 @@ module.exports = {
     activeHeaderLinks: false,
     sidebarDepth: 0,
     docsDir: 'docs',
+    docsVersion,
     algolia: {
       apiKey: 'af17a113c6a11af8057592a3120ffd3b',
       indexName: 'openhab',


### PR DESCRIPTION
Allows to switch between openhab.org (stable), next.openhab.org (latest)
and provide a link to the former v2 website.
Will be updated once we have archived versions.

Add the current version (from the OH_DOCS_VERSION
env variable) to the themeConfig object for easy
access.

Signed-off-by: Yannick Schaus <github@schaus.net>