### PR TITLE
Feature missing automation/voice add-ons

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -12,7 +12,7 @@ initial_gallery:
   automation:
      title: "Automation"
      description: "Automation add-ons extend the functionality of the rule engine, such as additional choices of scripting languages."
-     featured: ["jythonscripting", "groovyscripting"]
+     featured: ["jsscripting", "jythonscripting", "groovyscripting", "pidcontroller"]
      all: true
   persistence:
     title: "Data Persistence"
@@ -25,7 +25,7 @@ initial_gallery:
   voice:
     title: "Voice"
     description: "These add-ons provide voice enabling features, such as text-to-speech, speech-to-text etc."
-    featured: ["googletts", "mactts", "marytts", "picotts", "voicerss"]
+    featured: ["googletts", "mactts", "marytts", "picotts", "pollytts", "voicerss"]
     all: true
 meta:
   - name: og:title


### PR DESCRIPTION
These types don't have an all button because there aren't many.
If the missing add-ons are featured, they can be more easily discovered.

---

There's also https://github.com/openhab/openhab-docs/pull/1574 to add images for these add-ons.