### PR TITLE
Version switcher improvements

### DIFF
--- a/.vuepress/components/DocPreviousVersions.vue
+++ b/.vuepress/components/DocPreviousVersions.vue
@@ -1,11 +1,21 @@
 <template>
   <div class="page-versions">
     <ul class="version-switcher">
-      <li><a :href="siteUrl('Stable')" class="version-button" :class="{ current: currentVersion === 'Stable' }">Stable</a></li>
-      <li><a :href="siteUrl('Latest')" class="version-button" :class="{ current: currentVersion === 'Latest' }">Latest</a></li>
+      <li><a :href="siteUrl('Stable')" class="version-button" :class="{ current: currentVersion === 'Stable' }">Stable <small>({{stableVersion}})</small></a></li>
+      <li><a :href="siteUrl('Latest')" class="version-button" :class="{ current: currentVersion === 'Latest' }">Latest <small>({{latestVersion}})</small></a></li>
     </ul>
-    <div class="other-versions">
-      <a :href="siteUrl('v2')" @click="switchVersion('2.x')">v2.5</a>
+    <div class="archived-versions">
+      <div class="dropdown-wrapper" :class="{ archiveDropdownOpen }">
+        <a class="dropdown-title" @click="archiveDropdownOpen = !archiveDropdownOpen">
+          <span class="title">Archived</span>
+          <span class="arrow down"></span>
+        </a>
+        <ul class="nav-dropdown" v-show="archiveDropdownOpen">
+          <li v-for="version in previousVersions" :key="version.version" class="dropdown-item">
+            <a :href="siteUrl(version)">{{version.version}}</a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </template>
@@ -41,6 +51,41 @@
   a
     color #2c3e50 !important
 
+.archived-versions
+  white-space nowrap
+  font-size 9pt
+  height 14px
+  user-select none
+  display flex
+  flex-direction row
+  justify-content center
+  .dropdown-wrapper
+    height 1.8rem !important
+
+  .dropdown-title
+    display block
+    font-size 13px
+    font-weight normal
+    color black
+    cursor pointer
+    &:hover
+      text-decoration none !important
+  .nav-dropdown
+    box-sizing border-box
+    overflow-y auto
+    top 100%
+    right 0
+    background-color #fff
+    padding 10px 0
+    text-align left
+    white-space nowrap
+    margin 0
+    position relative
+    top 0
+    a
+      color #2c3e50 !important
+
+
 @media (prefers-color-scheme: dark)
   .version-switcher
     .version-button
@@ -49,34 +94,43 @@
       &.current
         background #a6a6a6 !important
         color #fff !important
-  .other-versions
-    a
-      color #a6a6a6 !important
+  .archived-versions
+    .nav-dropdown
+      a
+        color #a6a6a6 !important
 </style>
 
 <script>
 export default {
   data () {
     return {
-      currentVersion: null
+      currentVersion: null,
+      stableVersion: null,
+      latestVersion: null,
+      previousVersions: [],
+      archiveDropdownOpen: false
     }
   },
   methods: {
     siteUrl (version) {
       if (version === this.currentVersion) return null
-      let url = (this.$page.path.indexOf('/addons') === 0) ? this.$page.path.substring(1) : this.$page.path.split('/')[1]
+      let url = this.$page.path.split('/')[1]
       if (version === 'Stable') {
         url = 'https://www.openhab.org/' + url
       } else if (version === 'Latest') {
         url = 'https://next.openhab.org/' + url
-      } else if (version === 'v2') {
-        url = 'https://v2.openhab.org/' + url
+      } else if (version.website) {
+        url = version.website + url
       }
       return url
     }
   },
-  mounted () {
+  created () {
     this.currentVersion = this.$site.themeConfig.docsVersion
+    const downloadPage = this.$site.pages.find((p) => p.path === '/download/')
+    this.stableVersion = downloadPage.frontmatter.currentVersion
+    this.latestVersion = downloadPage.frontmatter.currentSnapshotVersion.replace('-SNAPSHOT', '')
+    this.previousVersions = downloadPage.frontmatter.previousVersions
   }
 }
 </script>

--- a/download/README.md
+++ b/download/README.md
@@ -5,6 +5,9 @@ title: Download openHAB
 currentVersion: 3.0.2
 currentMilestoneVersion: 3.1.0.M4
 currentSnapshotVersion: 3.1.0-SNAPSHOT
+previousVersions:
+  - version: 2.5
+    website: https://v2.openhab.org/
 meta:
   - name: og:title
     content: Download openHAB


### PR DESCRIPTION
Add a dropdown for the archived versions list
Take the versions from the download page's frontmatter
Display the current/latest versions in the buttons
Always go to the root of the section when switching versions

Signed-off-by: Yannick Schaus <github@schaus.net>