### PR TITLE
Redirect qnap article to v2 docs

### DIFF
--- a/.vuepress/_redirects
+++ b/.vuepress/_redirects
@@ -19,6 +19,10 @@
 /download/milestones/*        https://openhab.jfrog.io/artifactory/libs-milestone-local/:splat 302
 /download/releases/*          https://openhab.jfrog.io/artifactory/libs-release-local/:splat 302
 
+# Redirect special docs articles
+
+/docs/installation/qnap https://v2.openhab.org/docs/installation/qnap 301
+
 # Redirect v1 addon docs to the v2 subdomain
 
 /addons/bindings/akm8681/ https://v2.openhab.org/addons/bindings/akm8681/ 301


### PR DESCRIPTION
Sidebar entry was already removed for the v3 docs, since we can't validate the functionality for openHAB 3.

I will remove the article completely now and provide a proper redirect for search results.