### PR TITLE
Fix Firefox Mobile layout problem

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -40,6 +40,7 @@ module.exports = {
   ],
   patterns: (noAddons) ? ['**/*.md', '**/*.vue', '!addons/**'] : ['**/*.md', '**/*.vue'],
   head: [
+    ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }],
     // ['link', { rel: 'stylesheet', href: `/fonts/fonts.css` }],
     ['link', { rel: 'icon', href: `/favicon.ico` }],
     ['link', { rel: 'shortcut icon', href: `/favicon.ico` }],


### PR DESCRIPTION
This PR fixes a problem with responsive layout of Firefox for Android.

To reproduce simply use the firefox app or the firefox screen-size test feature of the developer tools and go to an openHAB page like https://www.openhab.org/addons/

![grafik](https://user-images.githubusercontent.com/38973046/122461553-c53ae900-cfb3-11eb-915b-3f36b984f9a4.png)

For a bief moment you can see that it scales the site like it should be but it falls back to desktop mode eventually.

This behavior seems to persist since vuepress 1.4.1, you can read more about this here: https://github.com/vuejs/vuepress/issues/2369

Signed-off-by: Kevin Haunschmied <darkc.futarialone@gmail.com>