### PR TITLE
Add jrubyscripting to automation add-ons

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -12,7 +12,7 @@ initial_gallery:
   automation:
      title: "Automation"
      description: "Automation add-ons extend the functionality of the rule engine, such as additional choices of scripting languages."
-     featured: ["jsscripting", "jythonscripting", "groovyscripting", "pidcontroller"]
+     featured: ["jsscripting", "jythonscripting", "groovyscripting", "jrubyscripting", "pidcontroller"]
      all: true
   persistence:
     title: "Data Persistence"


### PR DESCRIPTION
For the newly merged jrubyscripting automation add-on. There doesn't seem to be any specific rule for ordering the items.