### PR TITLE
Revert "Point downloads for releases and snapshots to Github instead of Jfrog"

### DIFF
--- a/.vuepress/_redirects
+++ b/.vuepress/_redirects
@@ -17,8 +17,8 @@
 
 # Redirect download locations
 
-/download/milestones/*        https://github.com/openhab/openhab-distro/releases/download/:splat 302
-/download/releases/*          https://github.com/openhab/openhab-distro/releases/download/:splat 302
+/download/milestones/*        https://openhab.jfrog.io/artifactory/libs-milestone-local/:splat 302
+/download/releases/*          https://openhab.jfrog.io/artifactory/libs-release-local/:splat 302
 
 # Redirect special docs articles
 


### PR DESCRIPTION
Reverts openhab/website#358