### PR TITLE
Add JFrog reflecting redirects

### DIFF
--- a/.vuepress/_redirects
+++ b/.vuepress/_redirects
@@ -17,6 +17,15 @@
 
 # Redirect download locations
 
+## Explicit redirect reflecting the JFrog folder structure
+
+/download/milestones/org/openhab/distro/openhab/*           https://github.com/openhab/openhab-distro/releases/download/:splat 302
+/download/milestones/org/openhab/distro/openhab-addons/*    https://github.com/openhab/openhab-distro/releases/download/:splat 302
+
+/download/releases/org/openhab/distro/openhab/*             https://github.com/openhab/openhab-distro/releases/download/:splat 302
+/download/releases/org/openhab/distro/openhab-addons/*      https://github.com/openhab/openhab-distro/releases/download/:splat 302
+
+## General dynamic redirects
 /download/milestones/*        https://openhab.jfrog.io/artifactory/libs-milestone-local/:splat 302
 /download/releases/*          https://openhab.jfrog.io/artifactory/libs-release-local/:splat 302
 


### PR DESCRIPTION
This will add dynamic redirects to github release assets, reflecting the jfrog folder structure.
Need uploaded runtime/addon files, for all distro releases starting from 2.5.12.

This is currently meant as a workaround in case of additional JFrog outages.
Still to be discussed if we go for a redirect or proxy solution in a final version.

Reference: openhab/openhab-distro#1415