### PR TITLE
Show Java 17 required for testing as well as snapshot

### DIFF
--- a/.vuepress/components/InstallInstructions.vue
+++ b/.vuepress/components/InstallInstructions.vue
@@ -78,8 +78,8 @@
         <p v-if="selectedSystem === 'raspberry-pi'">For Raspberry Pi, however, we strongly recommend flashing the complete OS image, see above.</p>
       </div>
       <ol>
-        <li v-if="selectedVersion !== 'snapshot'">Install a recent Java 11 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-11-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
-        <li v-if="selectedVersion === 'snapshot'">Install a recent Java 17 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-17-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
+        <li v-if="selectedVersion === 'stable'">Install a recent Java 11 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-11-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
+        <li v-if="selectedVersion !== 'stable'">Install a recent Java 17 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-17-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
         <li>Add the repository key</li>
           <div class="language-shell"><pre class="language-shell"><code>curl -fsSL "https://openhab.jfrog.io/artifactory/api/gpg/key/public" | gpg --dearmor > openhab.gpg
 sudo mkdir /usr/share/keyrings
@@ -102,8 +102,8 @@ sudo chmod u=rw,g=r,o=r /usr/share/keyrings/openhab.gpg</code></pre></div>
       <hr>
       <h3>{{optionNumber('package')}}Install the RPM Packages (Recommended)</h3>
       <ol>
-        <li v-if="selectedVersion !== 'snapshot'">Install a recent Java 11 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-11-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
-        <li v-if="selectedVersion === 'snapshot'">Install a recent Java 17 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-17-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
+        <li v-if="selectedVersion === 'stable'">Install a recent Java 11 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-11-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
+        <li v-if="selectedVersion !== 'stable'">Install a recent Java 17 platform (we recommend <a target="_blank" href="https://www.azul.com/downloads/zulu-community/?version=java-17-lts&package=jdk">the Zulu builds of OpenJDK</a>)</li>
         <li>Create a new <code>/etc/yum.repos.d/openhab.repo</code> file with the following content:</li>
         <div class="language-ini">
 <pre class="language-ini"><code>[openHAB-{{selectedVersion === 'stable' ? 'Stable' : selectedVersion === 'testing' ? 'Testing' : 'Snapshots'}}]
@@ -166,7 +166,7 @@ usermod -a -G openhab myownuser
       </ol>
     </div>
 
-    <div v-if="selectedSystem !== 'docker' && (selectedVersion === 'stable' || selectedVersion === 'testing')">
+    <div v-if="selectedSystem !== 'docker' && selectedVersion === 'stable'">
       <hr>
       <h3>{{optionNumber('manual')}}Manual Installation</h3>
       <ol>
@@ -197,7 +197,7 @@ usermod -a -G openhab myownuser
       </ol>
     </div>
 
-    <div v-if="selectedSystem !== 'docker' && selectedVersion === 'snapshot'">
+    <div v-if="selectedSystem !== 'docker' && (selectedVersion === 'testing' || selectedVersion === 'snapshot')">
       <hr />
       <h3>Manual Installation</h3>
       <ol>


### PR DESCRIPTION
I tried to stick with what was there, but for consistency sake I wanted to change the conditions for docker to match those other two, being === 'stable" and !== 'stable' instead of (selectedVersion === 'testing' || selectedVersion === 'snapshot')

Solves #400 

I totally added the signed off to my commit. I don't know why DCO is failing, though these changes are pretty minimal. 