### PR TITLE
Release openHAB 4.0.0

### DIFF
--- a/download/README.md
+++ b/download/README.md
@@ -2,10 +2,12 @@
 sidebar: false
 layout: AboutPage
 title: Download openHAB
-currentVersion: 3.4.4
-currentMilestoneVersion: 4.0.0.RC1
-currentSnapshotVersion: 4.0.0-SNAPSHOT
+currentVersion: 4.0.0
+# currentMilestoneVersion: 4.1.0.M1
+currentSnapshotVersion: 4.1.0-SNAPSHOT
 previousVersions:
+  - version: "3.4"
+    website: https://v34.openhab.org/
   - version: "3.3"
     website: https://v33.openhab.org/
   - version: "3.2"

--- a/prepare-docs.rb
+++ b/prepare-docs.rb
@@ -460,9 +460,9 @@ FileUtils.cp_r(".vuepress/openhab-docs/developers/osgi/images", "docs/developer/
 FileUtils.cp_r(".vuepress/openhab-docs/developers/ide/images", "docs/developer/ide/images")
 
 # Additional files and images for the latest docs
-if $version == "final" then
+#if $version == "final" then
 
-    puts "-> Add additional sections only to the 'latest' docs."
+    #puts "-> Add additional sections only to the 'latest' docs."
 
     ["addons"].each { |subsection|
         Dir.glob(".vuepress/openhab-docs/developers/#{subsection}/*.md") { |path|
@@ -472,11 +472,11 @@ if $version == "final" then
         }
     }
 
-else
+#else
 
-    puts "-> Skipping additional doc parts that are not yet available in stable."
+#   puts "-> Skipping additional doc parts that are not yet available in stable."
 
-end
+#end
 
 ### ADDONS
 


### PR DESCRIPTION
to be merged, when the release build has suceeded.

All other preparations have been completed already.