### PR TITLE
openHAB 4 release blog post: Fix links

### DIFF
--- a/blog/2023-07-23-openhab-4-0-release.md
+++ b/blog/2023-07-23-openhab-4-0-release.md
@@ -73,7 +73,7 @@ There are three things I would like to point out: Units of Measurement, scriptin
 We finally made handling of units more consistent in openHAB.
 In some cases the "old" code had surprising effects (e.g. changing the display unit in a state description corrupted persisted data).
 
-I strongly recommend to re-read [the documentation](/docs/concepts/units-of-measurement.html) and the [upgrade instructions](https://github.com/openhab/openhab-distro/releases/tag/4.0.0#upgrading).
+I strongly recommend to re-read [the documentation](/docs/concepts/units-of-measurement.html) and the [upgrade instructions](https://github.com/openhab/openhab-distro/releases/tag/4.0.0#breaking-changes-that-require-manual-interaction-after-the-upgrade).
 
 To make a long story short: We now introduced `unit` metadata that fixes the unit for a given Item.
 This unit is assumed if a value with no unit is sent to the Item and the same unit is used when data is persisted.

--- a/blog/2023-07-23-openhab-4-0-release.md
+++ b/blog/2023-07-23-openhab-4-0-release.md
@@ -44,7 +44,7 @@ Finally, it is time to shout out to our top code contributors per repository (ha
 - Jan ([@J-N-K](https://github.com/J-N-K)) for openHAB core
 - Jacob ([@jlaur](https://github.com/jlaur)) for openHAB add-ons
 - Laurent ([@lolodomo](https://github.com/lolodomo)) for openHAB add-ons
-- Florian ([@florian-h05](https://github.com/florian-05)) for the openHAB web UIs
+- Florian ([@florian-h05](https://github.com/florian-h05)) for the openHAB web UIs
 
 All of them are also maintainers, which means besides of contributing code, they review pull requests and participate in discussions on GitHub issues.
 At present, there are 37 maintainers across all our repositories.


### PR DESCRIPTION
- Fixes my profile link.
- Fixes the link to the UoM upgrade instructions. Unfortunately, headings at the level we need aren‘t supported in links.

Ping @kaikreuzer.