### PR TITLE
ConsentBanner: Scope styling to prevent leakage

### DIFF
--- a/.vuepress/components/ConsentBanner.vue
+++ b/.vuepress/components/ConsentBanner.vue
@@ -91,7 +91,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .consent-banner {
     position: fixed;
     bottom: 0px;


### PR DESCRIPTION
Scoping the styles to prevent style leakage, preventing unwanted style changes in other components.

See https://github.com/openhab/website/issues/406#issuecomment-1766907624 for an example where this is happening.