### PR TITLE
Fix JavaDoc

### DIFF
--- a/prepare-docs.rb
+++ b/prepare-docs.rb
@@ -680,7 +680,7 @@ system("ruby generate_iconset_doc.rb .vuepress/openhab-docs/_addons_iconsets cla
 
 # Publish latest Javadoc
 puts ">>> Downloading and extracting latest Javadoc from Jenkins"
-`rm javadoc-latest.tar.gz`
+`[ -e javadoc-latest.tar.gz ] && rm javadoc-latest.tar.gz`
 `wget -nv https://ci.openhab.org/job/openHAB-JavaDoc/lastSuccessfulBuild/artifact/target/javadoc-latest.tgz`
 `tar xzvf javadoc-latest.tgz --strip 2 && rm -r .vuepress/public/javadoc/latest/* && mv apidocs/ .vuepress/public/javadoc/latest`
 


### PR DESCRIPTION
Regression from #445.

The change in #445 meant to fix an issue with the local website build being executed multiple times,
but the clean build environment in Netlify caused the JavaDoc download to fail because of the failing rm command.