### PR TITLE
Meaningful label in addon reference

### DIFF
--- a/.vuepress/components/AddonSearch.vue
+++ b/.vuepress/components/AddonSearch.vue
@@ -28,7 +28,7 @@
                 <img v-if="addon.frontmatter.logo" :src="addon.frontmatter.logo.replace('images/addons/', '/logos/')" :title="addon.frontmatter.label" :alt="addon.frontmatter.label" />
                 <strong v-else><img src="/openhab-logo-square.png" width="60"><br />{{addon.frontmatter.label}}</strong>
               </div>
-              <div class="type">{{addon.frontmatter.title}}</div>
+              <div class="type">{{addon.frontmatter.label}}</div>
             </router-link>
           </li>
         </transition-group>
@@ -45,7 +45,7 @@
                 <img v-if="addon.frontmatter.logo" :src="addon.frontmatter.logo.replace('images/addons/', '/logos/')" :title="addon.frontmatter.label" :alt="addon.frontmatter.label" />
                 <strong v-else><img src="/openhab-logo-square.png" width="60"><br />{{addon.frontmatter.label}}</strong>
               </div>
-              <div class="type">{{addon.frontmatter.label}}</div>
+              <div class="type">{{addon.frontmatter.title}}</div>
             </router-link>
           </li>
         </transition-group>

--- a/.vuepress/components/AddonSearch.vue
+++ b/.vuepress/components/AddonSearch.vue
@@ -28,7 +28,7 @@
                 <img v-if="addon.frontmatter.logo" :src="addon.frontmatter.logo.replace('images/addons/', '/logos/')" :title="addon.frontmatter.label" :alt="addon.frontmatter.label" />
                 <strong v-else><img src="/openhab-logo-square.png" width="60"><br />{{addon.frontmatter.label}}</strong>
               </div>
-              <div class="type">{{addon.frontmatter.type}}</div>
+              <div class="type">{{addon.frontmatter.title}}</div>
             </router-link>
           </li>
         </transition-group>
@@ -45,7 +45,7 @@
                 <img v-if="addon.frontmatter.logo" :src="addon.frontmatter.logo.replace('images/addons/', '/logos/')" :title="addon.frontmatter.label" :alt="addon.frontmatter.label" />
                 <strong v-else><img src="/openhab-logo-square.png" width="60"><br />{{addon.frontmatter.label}}</strong>
               </div>
-              <div class="type">{{addon.frontmatter.type}}</div>
+              <div class="type">{{addon.frontmatter.label}}</div>
             </router-link>
           </li>
         </transition-group>


### PR DESCRIPTION
The addon reference page currently shows binding, io... underneath the logo. The logo is not always very clear, so a proper label would make it clearer what addon is represented.

See https://github.com/openhab/openhab-docs/pull/2185#issuecomment-1960911364

@stefan-hoehn I don't have a full website or doc development environment, so this may need a little test before merging.

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>