### PR TITLE
npm build script: Respect ARGUMENTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev": "npx vuepress dev",
     "prepare-docs": "ruby prepare-docs.rb $ARGUMENTS",
     "add-blog-meta": "ruby add-blog-meta.rb",
-    "build": "ruby prepare-docs.rb && ruby add-blog-meta.rb && vuepress build .",
+    "build": "npm run prepare-docs && ruby add-blog-meta.rb && vuepress build .",
     "build-only": "vuepress build .",
     "prebuild-local": "npm run prepare-docs",
     "build-local": "npm run dev --silent",


### PR DESCRIPTION
#456 made the prepare-docs step configurable through arguments passed in with the ARGUMENTS env var. However did the npm build script not respect them, this fixes this.