### PR TITLE
Fix dark mode scrollbars in Chrome

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -234,6 +234,8 @@ a[href*='.openhab.org'] .outbound
 /*** DARK MODE 😎 ***/
 
 @media (prefers-color-scheme: dark)
+    :root
+        color-scheme dark
     html, body
         background-color rgb(17, 17, 17)
         color rgb(221, 221, 221)


### PR DESCRIPTION
This fixes the issue that when using Chrome the scrolbars are still very bright and not dark.

### Before

![Screenshot from 2024-06-14 22-40-46](https://github.com/openhab/website/assets/12213581/70798831-cf41-4fda-b090-17c7bf390f6b)

### After

![Screenshot from 2024-06-14 22-40-28](https://github.com/openhab/website/assets/12213581/51c91b91-82cc-44b2-82ac-65f640229eaf)
