### PR TITLE
Add missing LICENSE to OS logos

### DIFF
--- a/.vuepress/public/os/LICENSE
+++ b/.vuepress/public/os/LICENSE
@@ -1,0 +1,5 @@
+Note: These images are NOT made available under the repo license (EPL).
+
+All product names, trademarks and registered trademarks are property of their respective owners.
+All company, product and service names used are for identification purposes only.
+Use of these names, trademarks and brands does not imply endorsement.


### PR DESCRIPTION
The OS logos are not under the repo license, so we have to note that.