### PR TITLE
Prevent redundant binding entries in sidebar

### DIFF
--- a/prepare-docs.rb
+++ b/prepare-docs.rb
@@ -623,10 +623,12 @@ puts "➡️ Writing add-ons arrays to files for sidebar navigation"
       Dir.foreach("addons/#{type}") do |dir|
         unless dir.include?(".")
           # puts dir
+          found = false
           File.readlines("addons/#{type}/#{dir}/readme.md").each do |line|
-            if line =~ /^label:/
+            if line =~ /^label:/ && !found
               title = line.gsub("label: ", "").gsub("\n", "")
               file.puts "\t['#{type}/#{dir}/', '#{title}']," unless title =~ /1\.x/
+              found = true
             end
           end
         end


### PR DESCRIPTION
There are redundant entries in the Add-ons page sidebar for the following bindings: govee, proteusecometer and salus (3x).

![redundant](https://github.com/user-attachments/assets/5be897c7-d6db-46d1-be65-16c6254e9d07)

Each redundancy appears to be caused by having the text `label: ...` at the beginning of a line in the content of the README.md file of the affected bindings:

![search](https://github.com/user-attachments/assets/2dfb70a5-ffe3-4814-83a8-9e956b701351)

This PR should prevent the redundancies by stopping the processing of a readme after the first `label: ...` text is encountered.